### PR TITLE
Implement DeviceCopy for Complex numbers

### DIFF
--- a/crates/cust/Cargo.toml
+++ b/crates/cust/Cargo.toml
@@ -12,6 +12,7 @@ cust_raw = { path = "../cust_raw", version = "0.11.2"}
 bitflags = "1.2"
 cust_derive = { path = "../cust_derive", version = "0.1" }
 vek = { version = "0.15.1", optional = true }
+num-complex = { version = "0.4", optional = true }
 
 [build-dependencies]
 find_cuda_helper = { path = "../find_cuda_helper", version = "0.1" }

--- a/crates/cust/src/memory/mod.rs
+++ b/crates/cust/src/memory/mod.rs
@@ -286,3 +286,6 @@ impl_device_copy_vek! {
     CubicBezier2, CubicBezier3,
     Quaternion,
 }
+
+#[cfg(feature = "num-complex")]
+unsafe impl<T: DeviceCopy> DeviceCopy for num_complex::Complex<T> {}


### PR DESCRIPTION
This PR adds an optional implementation of `DeviceCopy` for Complex numbers. This can be very valuable for scientific computing. The `num_complex::Complex` type is already `Copy` and `#[repr(C)]`.