### PR TITLE
Fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.2-cudnn8-devel-ubuntu18.04
+FROM nvidia/cuda:11.4.1-cudnn8-devel-ubuntu18.04
 
 # Update default packages
 RUN apt-get update
@@ -16,7 +16,6 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
 
 # get prebuilt llvm
-# COPY clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz .
 RUN curl -O https://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz &&\
     xz -d /clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz &&\
     tar xf /clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar &&\
@@ -24,10 +23,15 @@ RUN curl -O https://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ub
     mv /clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04 /root/llvm
 
 # set env
-ENV LLVM_CONFIG="/root/llvm/bin/llvm-config"
-ENV CUDA_ROOT="/usr/local/cuda"
+ENV LLVM_CONFIG=/root/llvm/bin/llvm-config
+ENV CUDA_ROOT=/usr/local/cuda
 ENV CUDA_PATH=$CUDA_ROOT
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info
-ENV PATH="$CUDA_ROOT/nvvm/lib64:/root/.cargo/bin:$PATH"
-ENV LD_LIBRARY_PATH=$PATH
+ENV PATH=$CUDA_ROOT/nvvm/lib64:/root/.cargo/bin:$PATH
+
+# make ld aware of necessary *.so libraries
+RUN echo $CUDA_ROOT/lib64 >> /etc/ld.so.conf &&\
+    echo $CUDA_ROOT/compat >> /etc/ld.so.conf &&\
+    echo $CUDA_ROOT/nvvm/lib64 >> /etc/ld.so.conf &&\
+    ldconfig

--- a/guide/src/guide/getting_started.md
+++ b/guide/src/guide/getting_started.md
@@ -5,7 +5,7 @@ This section covers how to get started writing GPU crates with `cuda_std` and `c
 ## Required Libraries
 
 Before you can use the project to write GPU crates, you will need a couple of prerequisites:
-- [The CUDA SDK](https://developer.nvidia.com/cuda-downloads), version `11.2` or higher. This is only for building
+- [The CUDA SDK](https://developer.nvidia.com/cuda-downloads), version `11.2` or higher (and the appropriate driver - [see cuda release notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)) . This is only for building
 GPU crates, to execute built PTX you only need CUDA 9+.
 
 - LLVM 7.x (7.0 to 7.4), The codegen searches multiple places for LLVM:
@@ -17,6 +17,8 @@ GPU crates, to execute built PTX you only need CUDA 9+.
 - The OptiX SDK if using the optix library (the pathtracer example uses it for denoising).
 
 - You may also need to add `libnvvm` to PATH, the builder should do it for you but in case it does not work, add libnvvm to PATH, it should be somewhere like `CUDA_ROOT/nvvm/bin`,
+
+- You may wish to use or consult the bundled [Dockerfile](#docker) to assist in your local config
 
 ## rust-toolchain
 
@@ -194,12 +196,15 @@ Then execute it using cust.
 There is also a [Dockerfile](Dockerfile) prepared as a quickstart with all the necessary libraries for base cuda development.
 
 You can use it as follows (assuming your clone of Rust-CUDA is at the absolute path `RUST_CUDA`):
-
+ - Ensure you have Docker setup to [use gpus](https://docs.docker.com/config/containers/resource_constraints/#gpu)
  - Build `docker build -t rust-cuda $RUST_CUDA`
- - Run `docker run -it -v $RUST_CUDA:/root/rust-cuda --entrypoint /bin/b
-ash rust-cuda`
-
-Running will drop you into the container
-s shell and you will find the project at `~/rust-cuda`
-
-Note: refer to [rust-toolchain][#rust-toolchain] to ensure you are using the correct toolchain in your project.
+ - Run `docker run -it --gpus all -v $RUST_CUDA:/root/rust-cuda --entrypoint /bin/bash rust-cuda`
+    * Running will drop you into the container's shell and you will find the project at `~/rust-cuda`
+ - If all is well, you'll be able to `cargo run` in `~/rust-cuda/examples/cuda/cpu/add`
+ 
+**Notes:**
+1. refer to [rust-toolchain](#rust-toolchain) to ensure you are using the correct toolchain in your project.
+2. despite using Docker, your machine will still need to be running a compatible driver, in this case for Cuda 11.4.1 it is >=470.57.02
+3. if you have issues within the container, it can help to start ensuring your gpu is recognized
+    * ensure `nvidia-smi` provides meaningful output in the container
+    * NVidia provides a number of samples https://github.com/NVIDIA/cuda-samples. In particular, you may want to try `make`ing and running the [`deviceQuery`](https://github.com/NVIDIA/cuda-samples/tree/ba04faaf7328dbcc87bfc9acaf17f951ee5ddcf3/Samples/deviceQuery) sample. If all is well you should see many details about your gpu


### PR DESCRIPTION
Apologies for the minor PRs in succession. I realized there were some minor issues with the Dockerfile that are now fixed and running the add example successfully seems to confirm it is working properly.

Details: The primary issue was that building succeeded, but running failed to create a context. This was somehow related to `ld` not finding the shared objects despite being in `LD_LIBRARY_PATH`. I reverted to `ldconfig` and this fixed the issue. 

Starting this PR as a draft to hear opinions on whether the Dockerfile should optionally include optix with a build argument. I have not investigated this much but I can look into it. 