### PR TITLE
docs: add `output` file hack to tips

### DIFF
--- a/guide/src/guide/tips.md
+++ b/guide/src/guide/tips.md
@@ -12,3 +12,9 @@ will get much better in the future but currently it will cause some undesirable 
 yield confusing `InvalidAddress` errors. If you are getting such an error, run the executable in cuda-memcheck,
 it should yield a write failure to `Local` memory at an address of about 16mb. You can also put the ptx file through
 `cuobjdump` and it should yield ptxas warnings for functions without a statically known stack usage.
+
+
+## Build
+
+- If `rustc_codegen_nvvm` has to rebuild on every build, you've encountered what appears to be a cargo bug. As a 
+workaround, edit `target/{release/debug}/build/rustc_codegen_nvvm-<some hash>/output` to set its edit date to now (for example using `touch` on linux, or just editing some content and then setting it back). After a few rebuilds it won't rebuild again and your compile times will become sane again.


### PR DESCRIPTION
When I built my project, `rustc_codegen_nvvm` rebuilt on every subsequent build of my program, even if I just changed the CPU crate code. Someone on the discord server shared their trick on how to fix it, by touching the `output` file in the `target` or `rustc_codegen_nvvm` and it worked for me, so I added it to the guide.
