### PR TITLE
Fix: cust compilation errors with no-default-features

### DIFF
--- a/crates/cust/src/memory/device/device_buffer.rs
+++ b/crates/cust/src/memory/device/device_buffer.rs
@@ -5,7 +5,7 @@ use crate::memory::{cuda_free_async, DevicePointer};
 use crate::memory::{cuda_malloc_async, DeviceCopy};
 use crate::stream::Stream;
 use crate::sys as cuda;
-#[cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
+#[cfg(feature = "bytemuck")]
 pub use bytemuck;
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodCastError, Zeroable};
@@ -282,6 +282,7 @@ impl<T: DeviceCopy + Zeroable> DeviceBuffer<T> {
     }
 }
 
+#[cfg(feature = "bytemuck")]
 fn casting_went_wrong(src: &str, err: PodCastError) -> ! {
     panic!("{}>{:?}", src, err);
 }


### PR DESCRIPTION
Cust does currently not build with `--no-default-features`. This PR fixes it.

I removed `#[cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]` since this is not a public module and will not be documented by default. In addition it seems like the idea is to support implicit adding based on `cfg` in the future? Let me know if this was a mistake and I should re-add it.

Also, should cust be built with `--no-default-features` in CI? Or is it not worth the added compile time in CI?