### PR TITLE
Fixed `impl_glam|mint|vek` feature flags being an illusion of choice

### DIFF
--- a/crates/cust/Cargo.toml
+++ b/crates/cust/Cargo.toml
@@ -24,7 +24,7 @@ vek = { version = "0.15.1", optional = true, default-features = false }
 bytemuck = { version = "1.7.3", optional = true }
 
 [features]
-default= ["bytemuck"]
+default= ["bytemuck", "impl_glam", "impl_mint", "impl_vek"]
 impl_glam = ["cust_core/glam", "glam"]
 impl_mint = ["cust_core/mint", "mint"]
 impl_vek = ["cust_core/vek", "vek"]

--- a/crates/cust_core/Cargo.toml
+++ b/crates/cust_core/Cargo.toml
@@ -14,6 +14,3 @@ mint = { version = "^0.5", optional = true }
 half = { version = "1.8", optional = true }
 num-complex = { version = "0.4", optional = true }
 cust_derive = { path = "../cust_derive", version = "0.2" }
-
-[features]
-default = ["vek", "glam", "mint"]


### PR DESCRIPTION
I noticed that it is not possible to disable these features because `cust_core` (which `cust` depends on) uses them as default features but exposes no way to turn them off.