### PR TITLE
Fix: add Debian's installation to default paths

### DIFF
--- a/crates/find_cuda_helper/src/lib.rs
+++ b/crates/find_cuda_helper/src/lib.rs
@@ -130,6 +130,7 @@ pub fn find_cuda_lib_dirs() -> Vec<PathBuf> {
     for e in glob::glob("/usr/local/cuda-*").unwrap().flatten() {
         candidates.push(e)
     }
+    candidates.push(PathBuf::from("/usr/lib/cuda"));
 
     let mut valid_paths = vec![];
     for base in &candidates {


### PR DESCRIPTION
When you install `nvidia-cuda-toolkit` on Debian, it installs the
CUDA libraries into `/usr/lib/cuda`. Add this path to the default
search paths.

I only use `cust` and with this patch, I can compile my code without any additional environment variables. I know that probably few people use the distro versions of the NVIDIA tools, but I do as my machine doesn't even have an NVIDIA GPU.