### PR TITLE
Readme: Guide links to github page instead of source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </p>
 
   <h3>
-    <a href="guide">Guide</a>
+    <a href="https://rust-gpu.github.io/Rust-CUDA/guide/index.html">Guide</a>
     <span> | </span>
     <a href="guide/src/guide/getting_started.md">Getting Started</a>
     <span> | </span>


### PR DESCRIPTION
I couldn't find a link to the rendered book, so I added it.