### PR TITLE
Added UnsupportedPtxVersion to the error enum

### DIFF
--- a/crates/cust/src/error.rs
+++ b/crates/cust/src/error.rs
@@ -52,6 +52,7 @@ pub enum CudaError {
     InvalidPtx = 218,
     InvalidGraphicsContext = 219,
     NvlinkUncorrectable = 220,
+    UnsupportedPtxVersion = 222,
     InvalidSource = 300,
     FileNotFound = 301,
     SharedObjectSymbolNotFound = 302,
@@ -159,6 +160,9 @@ impl ToResult for cudaError_enum {
             }
             cudaError_enum::CUDA_ERROR_PEER_ACCESS_UNSUPPORTED => {
                 Err(CudaError::PeerAccessUnsupported)
+            }
+            cudaError_enum::CUDA_ERROR_UNSUPPORTED_PTX_VERSION => {
+                Err(CudaError::UnsupportedPtxVersion)
             }
             cudaError_enum::CUDA_ERROR_INVALID_PTX => Err(CudaError::InvalidPtx),
             cudaError_enum::CUDA_ERROR_INVALID_GRAPHICS_CONTEXT => {


### PR DESCRIPTION
Got an unknown error, but found out after a bit of debugging that it is only a not yet supported error code.
I'm not 100% sure about the value `222`. Apparently that is `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`, but I didn't found an official source for this.