### PR TITLE
Fix: make UUID retrieval more portable

### DIFF
--- a/crates/cust/src/device.rs
+++ b/crates/cust/src/device.rs
@@ -342,7 +342,7 @@ impl Device {
     /// # }
     /// ```
     pub fn uuid(self) -> CudaResult<[u8; 16]> {
-        let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
+        let mut cu_uuid = CUuuid { bytes: [0; 16] };
         unsafe {
             cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
         }


### PR DESCRIPTION
The `CUuuid` byte type is `std::os::raw::c_char` and it depends on the platform, whether it is `i8` or `u8` in Rust. With just passing in `0` without a type identifier, both cases are handled. This makes the code more portable.