### PR TITLE
Port to more current rust-nightly

### DIFF
--- a/crates/cuda_builder/src/lib.rs
+++ b/crates/cuda_builder/src/lib.rs
@@ -376,10 +376,12 @@ fn invoke_rustc(builder: &CudaBuilder) -> Result<PathBuf, CudaBuilderError> {
 
     let new_path = get_new_path_var();
 
-    let mut rustflags = vec![format!(
-        "-Zcodegen-backend={}",
-        rustc_codegen_nvvm.display(),
-    )];
+    let mut rustflags = vec![
+        format!("-Zcodegen-backend={}", rustc_codegen_nvvm.display(),),
+        "-Zcrate-attr=feature(register_tool)".to_string(),
+        "-Zcrate-attr=register_tool(rust_cuda)".to_string(),
+        "-Zcrate-attr=no_std".to_string(),
+    ];
 
     if let Some(emit) = &builder.emit {
         let string = match emit {

--- a/crates/cuda_std/src/atomic/intrinsics.rs
+++ b/crates/cuda_std/src/atomic/intrinsics.rs
@@ -1,6 +1,7 @@
 //! Raw CUDA-specific atomic functions that map to PTX instructions.
 
 use crate::gpu_only;
+use core::arch::asm;
 use core::concat;
 use paste::paste;
 

--- a/crates/cuda_std/src/lib.rs
+++ b/crates/cuda_std/src/lib.rs
@@ -23,15 +23,11 @@
 
 #![cfg_attr(
     target_os = "cuda",
-    no_std,
     feature(
-        register_attr,
         alloc_error_handler,
-        asm,
         asm_experimental_arch,
         link_llvm_intrinsics
     ),
-    register_attr(nvvm_internal)
 )]
 
 extern crate alloc;
@@ -49,7 +45,7 @@ pub mod cfg;
 pub mod ptr;
 pub mod shared;
 pub mod thread;
-pub mod warp;
+// pub mod warp;
 
 mod float_ext;
 

--- a/crates/cuda_std/src/mem.rs
+++ b/crates/cuda_std/src/mem.rs
@@ -1,8 +1,8 @@
 //! Support for allocating memory and using `alloc` using CUDA memory allocation system-calls.
-
 use crate::gpu_only;
 #[cfg(any(target_arch = "nvptx", target_arch = "nvptx64"))]
 use alloc::alloc::*;
+use core::arch::asm;
 #[cfg(any(target_arch = "nvptx", target_arch = "nvptx64"))]
 use core::ffi::c_void;
 

--- a/crates/cuda_std/src/misc.rs
+++ b/crates/cuda_std/src/misc.rs
@@ -1,6 +1,6 @@
 //! Misc functions that do not exactly fit into other categories.
-
 use crate::gpu_only;
+use core::arch::asm;
 
 /// Suspends execution of the kernel, usually to pause at a specific point when debugging in a debugger.
 #[gpu_only]

--- a/crates/cuda_std/src/ptr.rs
+++ b/crates/cuda_std/src/ptr.rs
@@ -1,6 +1,6 @@
 //! CUDA-specific pointer handling logic.
-
 use crate::gpu_only;
+use core::arch::asm;
 
 /// Special areas of GPU memory where a pointer could reside.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/cuda_std/src/shared.rs
+++ b/crates/cuda_std/src/shared.rs
@@ -77,7 +77,7 @@ pub fn dynamic_shared_mem<T>() -> *mut T {
     extern "C" {
         // need to use nvvm_internal and not address_space because address_space only parses
         // static definitions, not extern static definitions.
-        #[nvvm_internal(addrspace(3))]
+        #[rust_cuda::nvvm_internal(addrspace(3))]
         #[allow(improper_ctypes)]
         // mangle it a bit to make sure nobody makes the same thing
         #[link_name = "_Zcuda_std_dyn_shared"]

--- a/crates/cuda_std/src/thread.rs
+++ b/crates/cuda_std/src/thread.rs
@@ -17,7 +17,7 @@
 //! The most important structure after threads, thread blocks arrange
 
 // TODO: write some docs about the terms used in this module.
-
+use core::arch::asm;
 use cuda_std_macros::gpu_only;
 use vek::{Vec2, Vec3};
 

--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -4,6 +4,7 @@
 //! thread blocks and execute in SIMT fashion.
 
 use crate::gpu_only;
+use core::arch::asm;
 use half::{bf16, f16};
 
 /// Synchronizes all of the threads inside of this warp according to `mask`.

--- a/crates/cuda_std_macros/src/lib.rs
+++ b/crates/cuda_std_macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use quote::{quote_spanned, ToTokens};
+use proc_macro2::{Span, TokenTree, Delimiter, Group};
+use quote::{quote_spanned, ToTokens, quote};
 use syn::{
     parse::Parse, parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, Error,
     FnArg, Ident, ItemFn, ReturnType, Stmt, Token,
@@ -27,7 +27,7 @@ pub fn kernel(input: proc_macro::TokenStream, item: proc_macro::TokenStream) -> 
     let mut item = parse_macro_input!(item as ItemFn);
     let no_mangle = parse_quote!(#[no_mangle]);
     item.attrs.push(no_mangle);
-    let internal = parse_quote!(#[cfg_attr(any(target_arch="nvptx", target_arch="nvptx64"), nvvm_internal(kernel(#input)))]);
+    let internal = parse_quote!(#[cfg_attr(any(target_arch="nvptx", target_arch="nvptx64"), rust_cuda::nvvm_internal(kernel(#input)))]);
     item.attrs.push(internal);
 
     // used to guarantee some things about how params are passed in the codegen.
@@ -231,7 +231,7 @@ pub fn address_space(attr: proc_macro::TokenStream, item: proc_macro::TokenStrea
     };
 
     let new_attr =
-        parse_quote!(#[cfg_attr(target_os = "cuda", nvvm_internal(addrspace(#addrspace_num)))]);
+        parse_quote!(#[cfg_attr(target_os = "cuda", rust_cuda::nvvm_internal(addrspace(#addrspace_num)))]);
     global.attrs.push(new_attr);
 
     global.into_token_stream().into()

--- a/crates/cust/Cargo.toml
+++ b/crates/cust/Cargo.toml
@@ -17,7 +17,7 @@ cust_core = { path = "../cust_core", version = "0.1.0"}
 cust_raw = { path = "../cust_raw", version = "0.11.2"}
 bitflags = "1.2"
 cust_derive = { path = "../cust_derive", version = "0.2" }
-glam = { version = "0.20", features=["cuda"], optional = true }
+glam = { version = "0.21", features=["cuda"], optional = true }
 mint = { version = "^0.5", optional = true }
 num-complex = { version = "0.4", optional = true }
 vek = { version = "0.15.1", optional = true, default-features = false }

--- a/crates/cust_core/Cargo.toml
+++ b/crates/cust_core/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../README.md"
 
 [dependencies]
 vek = { version = "0.15.1", default-features=false, features=["libm"], optional = true }
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false, optional=true }
+glam = { version = "0.21", features=["cuda", "libm"], default-features=false, optional=true }
 mint = { version = "^0.5", optional = true }
 half = { version = "1.8", optional = true }
 num-complex = { version = "0.4", optional = true }

--- a/crates/cust_core/src/lib.rs
+++ b/crates/cust_core/src/lib.rs
@@ -172,7 +172,7 @@ pub mod _hidden {
 
     #[cfg(feature = "glam")]
     impl_device_copy! {
-        glam::Vec2, glam::Vec3, glam::Vec4, glam::IVec2, glam::IVec3, glam::IVec4,
+        glam::Vec2, glam::Vec3, glam::Vec4, glam::IVec2, glam::IVec3, glam::IVec4, glam::Mat3, glam::Mat4
     }
 
     #[cfg(feature = "mint")]

--- a/crates/optix/Cargo.toml
+++ b/crates/optix/Cargo.toml
@@ -20,7 +20,7 @@ cust = { version = "0.3", path = "../cust", features=["impl_mint"] }
 cust_raw = { version = "0.11.2", path = "../cust_raw" }
 cfg-if = "1.0.0"
 bitflags = "1.3.2"
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false, optional=true }
+glam = { version = "0.21", features=["cuda", "libm"], default-features=false, optional=true }
 half = { version = "^1.8", optional = true }
 memoffset = "0.6.4"
 mint = "0.5.8"

--- a/crates/optix/examples/ex02_pipeline/device/src/lib.rs
+++ b/crates/optix/examples/ex02_pipeline/device/src/lib.rs
@@ -1,9 +1,8 @@
-#![feature(asm)]
 #![cfg_attr(
     target_os = "cuda",
     no_std,
-    feature(register_attr),
-    register_attr(nvvm_internal)
+    feature(register_tool),
+    register_tool(nvvm_internal)
 )]
 // #![deny(warnings)]
 #![allow(clippy::missing_safety_doc)]

--- a/crates/optix/examples/rust/ex04_mesh_gpu/src/lib.rs
+++ b/crates/optix/examples/rust/ex04_mesh_gpu/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(
     target_os = "cuda",
     no_std,
-    feature(register_attr),
-    register_attr(nvvm_internal)
+    feature(register_tool),
+    register_tool(nvvm_internal)
 )]
 #![allow(non_snake_case, clippy::missing_safety_doc)]
 

--- a/crates/optix_device/Cargo.toml
+++ b/crates/optix_device/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Anders Langlands <anderslanglands@gmail.com>", "Riccardo D'Ambrosio 
 [dependencies]
 bitflags = "1.3.2"
 cuda_std = { version = "0.2", path = "../cuda_std" }
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false }
+glam = { version = "0.21", features=["cuda", "libm"], default-features=false }
 paste = "1.0.6"
 seq-macro = "0.3.0"
 cust_core = { version = "0.1", path = "../cust_core" }

--- a/crates/optix_device/src/lib.rs
+++ b/crates/optix_device/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(
     target_arch = "nvptx64",
     no_std,
-    feature(register_attr, asm, asm_experimental_arch),
-    register_attr(nvvm_internal)
+    feature(register_tool, asm, asm_experimental_arch),
+    register_tool(nvvm_internal)
 )]
 
 extern crate alloc;

--- a/crates/rustc_codegen_nvvm/Cargo.toml
+++ b/crates/rustc_codegen_nvvm/Cargo.toml
@@ -17,7 +17,9 @@ crate-type = ["dylib"]
 [dependencies]
 nvvm = { version = "0.1", path = "../nvvm" }
 rustc-demangle = "0.1.20"
+cstr = "0.2"
 libc = "0.2.97"
+libloading = "0.7"
 tar = "0.4.35"
 once_cell = "1.8.0"
 bitflags = "1.3.2"

--- a/crates/rustc_codegen_nvvm/src/allocator.rs
+++ b/crates/rustc_codegen_nvvm/src/allocator.rs
@@ -11,7 +11,7 @@ pub(crate) unsafe fn codegen(
     _tcx: TyCtxt<'_>,
     mods: &mut LlvmMod,
     kind: AllocatorKind,
-    has_alloc_error_handler: bool,
+    alloc_error_handler_kind: AllocatorKind,
 ) {
     let llcx = &*mods.llcx;
     let llmod = mods.llmod.as_ref().unwrap();
@@ -94,11 +94,7 @@ pub(crate) unsafe fn codegen(
     // -> ! DIFlagNoReturn
     llvm::Attribute::NoReturn.apply_llfn(llvm::AttributePlace::Function, llfn);
 
-    let kind = if has_alloc_error_handler {
-        AllocatorKind::Global
-    } else {
-        AllocatorKind::Default
-    };
+    let kind = alloc_error_handler_kind;
     let callee = kind.fn_name(sym::oom);
     let callee = llvm::LLVMRustGetOrInsertFunction(llmod, callee.as_ptr().cast(), callee.len(), ty);
 

--- a/crates/rustc_codegen_nvvm/src/debug_info/create_scope_map.rs
+++ b/crates/rustc_codegen_nvvm/src/debug_info/create_scope_map.rs
@@ -16,23 +16,29 @@ use super::metadata::file_metadata;
 use super::util::DIB;
 
 /// Produces DIScope DIEs for each MIR Scope which has variables defined in it.
+// FIXME(eddyb) almost all of this should be in `rustc_codegen_ssa::mir::debuginfo`.
 pub(crate) fn compute_mir_scopes<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     instance: Instance<'tcx>,
     mir: &Body<'tcx>,
-    fn_dbg_scope: &'ll DIScope,
     debug_context: &mut FunctionDebugContext<&'ll DIScope, &'ll DILocation>,
 ) {
-    // Find all the scopes with variables defined in them.
-    let mut has_variables = BitSet::new_empty(mir.source_scopes.len());
-
-    // Only consider variables when they're going to be emitted.
-    if cx.sess().opts.debuginfo == DebugInfo::Full {
+    // Find all scopes with variables defined in them.
+    let variables = if cx.sess().opts.debuginfo == DebugInfo::Full {
+        let mut vars = BitSet::new_empty(mir.source_scopes.len());
+        // FIXME(eddyb) take into account that arguments always have debuginfo,
+        // irrespective of their name (assuming full debuginfo is enabled).
+        // NOTE(eddyb) actually, on second thought, those are always in the
+        // function scope, which always exists.
         for var_debug_info in &mir.var_debug_info {
-            has_variables.insert(var_debug_info.source_info.scope);
+            vars.insert(var_debug_info.source_info.scope);
         }
-    }
-
+        Some(vars)
+    } else {
+        // Nothing to emit, of course.
+        None
+    };
+    let mut instantiated = BitSet::new_empty(mir.source_scopes.len());
     // Instantiate all scopes.
     for idx in 0..mir.source_scopes.len() {
         let scope = SourceScope::new(idx);
@@ -40,24 +46,25 @@ pub(crate) fn compute_mir_scopes<'ll, 'tcx>(
             cx,
             instance,
             mir,
-            fn_dbg_scope,
-            &has_variables,
+            &variables,
             debug_context,
+            &mut instantiated,
             scope,
         );
     }
+    assert!(instantiated.count() == mir.source_scopes.len());
 }
 
 fn make_mir_scope<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     instance: Instance<'tcx>,
     mir: &Body<'tcx>,
-    fn_dbg_scope: &'ll DIScope,
-    has_variables: &BitSet<SourceScope>,
+    variables: &Option<BitSet<SourceScope>>,
     debug_context: &mut FunctionDebugContext<&'ll DIScope, &'ll DILocation>,
+    instantiated: &mut BitSet<SourceScope>,
     scope: SourceScope,
 ) {
-    if debug_context.scopes[scope].dbg_scope.is_some() {
+    if instantiated.contains(scope) {
         return;
     }
 
@@ -67,9 +74,9 @@ fn make_mir_scope<'ll, 'tcx>(
             cx,
             instance,
             mir,
-            fn_dbg_scope,
-            has_variables,
+            variables,
             debug_context,
+            instantiated,
             parent,
         );
         debug_context.scopes[parent]
@@ -77,18 +84,19 @@ fn make_mir_scope<'ll, 'tcx>(
         // The root is the function itself.
         let loc = cx.lookup_debug_loc(mir.span.lo());
         debug_context.scopes[scope] = DebugScope {
-            dbg_scope: Some(fn_dbg_scope),
-            inlined_at: None,
             file_start_pos: loc.file.start_pos,
             file_end_pos: loc.file.end_pos,
+            ..debug_context.scopes[scope]
         };
+        instantiated.insert(scope);
         return;
     };
 
-    if !has_variables.contains(scope) && scope_data.inlined.is_none() {
+    if let Some(vars) = variables && !vars.contains(scope) && scope_data.inlined.is_none() {
         // Do not create a DIScope if there are no variables defined in this
         // MIR `SourceScope`, and it's not `inlined`, to avoid debuginfo bloat.
         debug_context.scopes[scope] = parent_scope;
+        instantiated.insert(scope);
         return;
     }
 
@@ -97,6 +105,8 @@ fn make_mir_scope<'ll, 'tcx>(
 
     let dbg_scope = match scope_data.inlined {
         Some((callee, _)) => {
+            // FIXME(eddyb) this would be `self.monomorphize(&callee)`
+            // if this is moved to `rustc_codegen_ssa::mir::debuginfo`.
             let callee = cx.tcx.subst_and_normalize_erasing_regions(
                 instance.substs,
                 ty::ParamEnv::reveal_all(),
@@ -108,7 +118,7 @@ fn make_mir_scope<'ll, 'tcx>(
         None => unsafe {
             llvm::LLVMRustDIBuilderCreateLexicalBlock(
                 DIB(cx),
-                parent_scope.dbg_scope.unwrap(),
+                parent_scope.dbg_scope,
                 file_metadata,
                 loc.line,
                 loc.col,
@@ -117,14 +127,17 @@ fn make_mir_scope<'ll, 'tcx>(
     };
 
     let inlined_at = scope_data.inlined.map(|(_, callsite_span)| {
+        // FIXME(eddyb) this doesn't account for the macro-related
+        // `Span` fixups that `rustc_codegen_ssa::mir::debuginfo` does.
         let callsite_scope = parent_scope.adjust_dbg_scope_for_span(cx, callsite_span);
         cx.dbg_loc(callsite_scope, parent_scope.inlined_at, callsite_span)
     });
 
     debug_context.scopes[scope] = DebugScope {
-        dbg_scope: Some(dbg_scope),
+        dbg_scope,
         inlined_at: inlined_at.or(parent_scope.inlined_at),
         file_start_pos: loc.file.start_pos,
         file_end_pos: loc.file.end_pos,
     };
+    instantiated.insert(scope);
 }

--- a/crates/rustc_codegen_nvvm/src/debug_info/util.rs
+++ b/crates/rustc_codegen_nvvm/src/debug_info/util.rs
@@ -45,10 +45,5 @@ pub(crate) fn get_namespace_for_item<'ll, 'tcx>(
     cx: &CodegenCx<'ll, 'tcx>,
     def_id: DefId,
 ) -> &'ll DIScope {
-    item_namespace(
-        cx,
-        cx.tcx
-            .parent(def_id)
-            .expect("get_namespace_for_item: missing parent?"),
-    )
+    item_namespace(cx, cx.tcx.parent(def_id))
 }

--- a/crates/rustc_codegen_nvvm/src/llvm.rs
+++ b/crates/rustc_codegen_nvvm/src/llvm.rs
@@ -335,6 +335,8 @@ pub(crate) enum MetadataType {
     MD_invariant_load = 6,
     MD_nontemporal = 9,
     MD_nonnull = 11,
+    MD_type = 19,
+    MD_kcfi_type = 36,
 }
 
 /// LLVMRustAsmDialect
@@ -346,14 +348,14 @@ pub enum AsmDialect {
     Intel,
 }
 
-impl AsmDialect {
-    pub fn from_generic(asm: rustc_ast::LlvmAsmDialect) -> Self {
-        match asm {
-            rustc_ast::LlvmAsmDialect::Att => AsmDialect::Att,
-            rustc_ast::LlvmAsmDialect::Intel => AsmDialect::Intel,
-        }
-    }
-}
+// impl AsmDialect {
+//     pub fn from_generic(asm: rustc_ast::LlvmAsmDialect) -> Self {
+//         match asm {
+//             rustc_ast::LlvmAsmDialect::Att => AsmDialect::Att,
+//             rustc_ast::LlvmAsmDialect::Intel => AsmDialect::Intel,
+//         }
+//     }
+// }
 
 /// LLVMRustDiagnosticKind
 #[derive(Copy, Clone)]
@@ -1585,6 +1587,18 @@ extern "C" {
         DestTy: &'a Type,
         Name: *const c_char,
     ) -> &'a Value;
+    // pub(crate) fn LLVMBuildFPToSISat<'a>(
+    //     B: &Builder<'a>,
+    //     Val: &'a Value,
+    //     DestTy: &'a Type,
+    //     Name: *const c_char,
+    // ) -> &'a Value;
+    // pub(crate) fn LLVMBuildFPToUISat<'a>(
+    //     B: &Builder<'a>,
+    //     Val: &'a Value,
+    //     DestTy: &'a Type,
+    //     Name: *const c_char,
+    // ) -> &'a Value;
     pub(crate) fn LLVMBuildUIToFP<'a>(
         B: &Builder<'a>,
         Val: &'a Value,

--- a/crates/rustc_codegen_nvvm/src/lto.rs
+++ b/crates/rustc_codegen_nvvm/src/lto.rs
@@ -148,7 +148,7 @@ pub(crate) fn run_thin(
 
 pub(crate) unsafe fn optimize_thin(
     cgcx: &CodegenContext<NvvmCodegenBackend>,
-    thin_module: &mut ThinModule<NvvmCodegenBackend>,
+    thin_module: ThinModule<NvvmCodegenBackend>,
 ) -> Result<ModuleCodegen<LlvmMod>, FatalError> {
     // essentially does nothing
     let diag_handler = cgcx.create_diag_handler();

--- a/crates/rustc_codegen_nvvm/src/mono_item.rs
+++ b/crates/rustc_codegen_nvvm/src/mono_item.rs
@@ -11,7 +11,7 @@ pub use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::mir::mono::{Linkage, Visibility};
 use rustc_middle::ty::layout::FnAbiOf;
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_middle::ty::{self, Instance, TypeFoldable};
+use rustc_middle::ty::{self, Instance, TypeFoldable, TypeVisitable};
 use tracing::trace;
 
 pub(crate) fn visibility_to_llvm(linkage: Visibility) -> llvm::Visibility {
@@ -94,8 +94,8 @@ impl<'ll, 'tcx> PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         attributes::from_fn_attrs(self, lldecl, instance);
 
         let def_id = instance.def_id();
-        let attrs = self.tcx.get_attrs(def_id);
-        let nvvm_attrs = NvvmAttributes::parse(self, attrs);
+        let attrs = self.tcx.get_attrs_unchecked(def_id);
+        let nvvm_attrs = NvvmAttributes::parse(self, &attrs);
 
         unsafe {
             // if this function is marked as being a kernel, add it

--- a/crates/rustc_codegen_nvvm/src/override_fns.rs
+++ b/crates/rustc_codegen_nvvm/src/override_fns.rs
@@ -27,7 +27,8 @@ fn should_override<'ll, 'tcx>(func: Instance<'tcx>, cx: &CodegenCx<'ll, 'tcx>) -
     if !is_libm {
         return false;
     }
-    let name = cx.tcx.item_name(func.def_id()).as_str();
+    let name_id = cx.tcx.item_name(func.def_id());
+    let name = name_id.as_str();
     let intrinsics = cx.intrinsics_map.borrow();
     let is_known_intrinsic = intrinsics.contains_key(format!("__nv_{}", name).as_str());
 
@@ -48,7 +49,8 @@ fn is_unsupported_libdevice_fn(name: &str) -> bool {
 }
 
 fn override_libm_function<'ll, 'tcx>(func: Instance<'tcx>, cx: &CodegenCx<'ll, 'tcx>) {
-    let name = cx.tcx.item_name(func.def_id()).as_str();
+    let name_id = cx.tcx.item_name(func.def_id());
+    let name = name_id.as_str();
     let nv_name = format!("__nv_{}", name);
     let intrinsic = cx.get_intrinsic(&nv_name);
 
@@ -57,6 +59,6 @@ fn override_libm_function<'ll, 'tcx>(func: Instance<'tcx>, cx: &CodegenCx<'ll, '
     let mut bx = Builder::build(cx, start);
 
     let params = llvm::get_params(llfn);
-    let llcall = bx.call(cx.type_i1(), intrinsic, &params, None);
+    let llcall = bx.call(cx.type_i1(), None, intrinsic, &params, None);
     bx.ret(llcall);
 }

--- a/crates/rustc_codegen_nvvm/src/target.rs
+++ b/crates/rustc_codegen_nvvm/src/target.rs
@@ -11,45 +11,44 @@ pub(crate) unsafe fn usize_ty(llcx: &'_ llvm::Context) -> &'_ Type {
 }
 
 pub fn target() -> Target {
+    let mut target_options = TargetOptions::default();
+    target_options.os = "cuda".into();
+    target_options.vendor = "nvidia".into();
+    target_options.linker_flavor = LinkerFlavor::Ptx;
+    // nvvm does all the linking for us; but technically its not a linker
+    target_options.linker = None;
+
+    target_options.cpu = "sm_30".into();
+
+    target_options.max_atomic_width = Some(64);
+
+    // Unwinding on CUDA is neither feasible nor useful.
+    target_options.panic_strategy = PanicStrategy::Abort;
+
+    // Needed to use `dylib` and `bin` crate types and the linker.
+    target_options.dynamic_linking = true;
+    target_options.executables = true;
+
+    target_options.only_cdylib = true;
+
+    // nvvm does all the work of turning the bitcode into ptx
+    target_options.obj_is_bitcode = true;
+
+    target_options.dll_prefix = "".into();
+    target_options.dll_suffix = ".ptx".into();
+    target_options.exe_suffix = ".ptx".into();
+
+    // Disable MergeFunctions LLVM optimisation pass because it can
+    // produce kernel functions that call other kernel functions.
+    // This behavior is not supported by PTX ISA.
+    target_options.merge_functions = MergeFunctions::Disabled;
+
     Target {
-        arch: "nvptx".to_string(),
-        data_layout: DATA_LAYOUT.to_string(),
-        llvm_target: "nvptx64-nvidia-cuda".to_string(),
+        arch: "nvptx".into(),
+        data_layout: DATA_LAYOUT.into(),
+        llvm_target: "nvptx64-nvidia-cuda".into(),
         pointer_width: 64,
 
-        options: TargetOptions {
-            os: "cuda".to_string(),
-            vendor: "nvidia".to_string(),
-            linker_flavor: LinkerFlavor::PtxLinker,
-            // nvvm does all the linking for us, but technically its not a linker
-            linker: None,
-
-            cpu: "sm_30".to_string(),
-
-            max_atomic_width: Some(64),
-
-            // Unwinding on CUDA is neither feasible nor useful.
-            panic_strategy: PanicStrategy::Abort,
-
-            // Needed to use `dylib` and `bin` crate types and the linker.
-            dynamic_linking: true,
-            executables: true,
-
-            only_cdylib: true,
-
-            // nvvm does all the work of turning the bitcode into ptx
-            obj_is_bitcode: true,
-
-            dll_prefix: "".to_string(),
-            dll_suffix: ".ptx".to_string(),
-            exe_suffix: ".ptx".to_string(),
-
-            // Disable MergeFunctions LLVM optimisation pass because it can
-            // produce kernel functions that call other kernel functions.
-            // This behavior is not supported by PTX ISA.
-            merge_functions: MergeFunctions::Disabled,
-
-            ..Default::default()
-        },
+        options: target_options,
     }
 }

--- a/examples/cuda/gpu/add_gpu/src/lib.rs
+++ b/examples/cuda/gpu/add_gpu/src/lib.rs
@@ -1,10 +1,3 @@
-#![cfg_attr(
-    target_os = "cuda",
-    no_std,
-    feature(register_attr),
-    register_attr(nvvm_internal)
-)]
-
 use cuda_std::prelude::*;
 
 #[kernel]

--- a/examples/cuda/gpu/path_tracer_gpu/src/lib.rs
+++ b/examples/cuda/gpu/path_tracer_gpu/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(
     target_os = "cuda",
     no_std,
-    feature(register_attr),
-    register_attr(nvvm_internal)
+    feature(register_tool),
+    register_tool(nvvm_internal)
 )]
 #![allow(clippy::missing_safety_doc)]
 

--- a/guide/src/guide/getting_started.md
+++ b/guide/src/guide/getting_started.md
@@ -62,8 +62,8 @@ Before we can write any GPU kernels, we must add a few directives to our `lib.rs
 #![cfg_attr(
     target_os = "cuda",
     no_std,
-    feature(register_attr),
-    register_attr(nvvm_internal)
+    feature(register_tool),
+    register_tool(nvvm_internal)
 )]
 
 use cuda_std::*;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-12-04"
-components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
+channel = "nightly-2022-12-10"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview", "rust-analyzer"]


### PR DESCRIPTION
- also port from register_attr to register_tool (approach shamelessly taken from rust-gpu)
- `add_gpu` example working
- Deactivate warp submodule as it does trigger some codegen issues

breaking:
- Inject "no_std" and "register_tool" crate flags via `cuda_builder`. The user has no longer to define the respective `cfg_attr` section in gpu code. Leaving them still in gpu code will result in a compile error from cargo. 


to be further tested:
- more complex examples/projects