### PR TITLE
LLVM Prebuilt Binary Download Fix

### DIFF
--- a/crates/rustc_codegen_nvvm/build.rs
+++ b/crates/rustc_codegen_nvvm/build.rs
@@ -89,6 +89,7 @@ fn find_llvm_config(target: &str) -> PathBuf {
 
     let out = env::var("OUT_DIR").expect("OUT_DIR was not set");
     let mut easy = Easy::new();
+    easy.ssl_verify_peer(false);
 
     easy.url(&url).unwrap();
     let _redirect = easy.follow_location(true).unwrap();


### PR DESCRIPTION
On windows I've been experiencing this problem where I can't seem to download the tar.gz without returning an error, this fixed it for me.