### PR TITLE
Udpate Add Example & Getting Started

### DIFF
--- a/examples/cuda/cpu/add/Cargo.toml
+++ b/examples/cuda/cpu/add/Cargo.toml
@@ -7,5 +7,18 @@ edition = "2021"
 cust = { version = "0.3", path = "../../../../crates/cust" }
 nanorand = "0.6.1"
 
+# We don't depend on these directly, but want to pin them to specific versions.
+# This is because we're bound to a specific rustc version but cargo will chose
+# the newest semver compatible versions anyway.
+log = "=0.4.17"
+regex-syntax = "=0.6.28"
+regex = "=1.7.1"
+thread_local = "=1.1.4"
+jobserver = "=0.1.25"
+cc = "=1.0.78"
+rayon = "=1.5.1"
+rayon-core = "=1.10.0"
+byteorder = "=1.4.0"
+
 [build-dependencies]
 cuda_builder = { version = "0.3", path = "../../../../crates/cuda_builder" }

--- a/guide/src/guide/getting_started.md
+++ b/guide/src/guide/getting_started.md
@@ -5,7 +5,7 @@ This section covers how to get started writing GPU crates with `cuda_std` and `c
 ## Required Libraries
 
 Before you can use the project to write GPU crates, you will need a couple of prerequisites:
-- [The CUDA SDK](https://developer.nvidia.com/cuda-downloads), version `11.2` or higher (and the appropriate driver - [see cuda release notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)) . This is only for building
+- [The CUDA SDK](https://developer.nvidia.com/cuda-downloads), version `11.2-11.8` (and the appropriate driver - [see cuda release notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)) . This is only for building
 GPU crates, to execute built PTX you only need CUDA 9+.
 
 - LLVM 7.x (7.0 to 7.4), The codegen searches multiple places for LLVM:


### PR DESCRIPTION
With the pinned versions `cargo run --bin add` works for me.

There is probably something similar TODO for the `path_tracer` example, but I haven't figured that out yet.