### PR TITLE
add new cuda default path for 24.04

### DIFF
--- a/crates/find_cuda_helper/src/lib.rs
+++ b/crates/find_cuda_helper/src/lib.rs
@@ -42,7 +42,7 @@ pub fn find_cuda_root() -> Option<PathBuf> {
 
     // If it wasn't specified by env var, try the default installation paths
     #[cfg(not(target_os = "windows"))]
-    let default_paths = ["/usr/local/cuda", "/opt/cuda"];
+    let default_paths = ["/usr/lib/cuda", "/usr/local/cuda", "/opt/cuda"];
     #[cfg(target_os = "windows")]
     let default_paths = ["C:/CUDA"]; // TODO (AL): what's the actual path here?
 


### PR DESCRIPTION
in Ubuntu 24.04 cuda libs are installed in directory:
```
/usr/lib/cuda
```
I propose that this be added to default "search" locations.