### PR TITLE
FIX: Remove nvptx target architecture conditions.

### DIFF
--- a/crates/cuda_std/src/lib.rs
+++ b/crates/cuda_std/src/lib.rs
@@ -76,7 +76,7 @@ pub mod prelude {
     };
 }
 
-#[cfg(any(target_arch = "nvptx", target_arch = "nvptx64"))]
+#[cfg(target_arch = "nvptx64")]
 #[alloc_error_handler]
 fn alloc_handler(layout: core::alloc::Layout) -> ! {
     core::panic!("Memory allocation of {} bytes failed", layout.size());
@@ -84,7 +84,7 @@ fn alloc_handler(layout: core::alloc::Layout) -> ! {
 
 // FIXME(RDambrosio016): For some very odd reason, this function causes an InvalidAddress error when called,
 // despite it having no reason for doing that. It needs more debugging to see what is causing it exactly. For now we just trap.
-#[cfg(any(target_arch = "nvptx", target_arch = "nvptx64"))]
+#[cfg(target_arch = "nvptx64")]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     // use crate::prelude::*;

--- a/crates/cuda_std_macros/src/lib.rs
+++ b/crates/cuda_std_macros/src/lib.rs
@@ -27,7 +27,7 @@ pub fn kernel(input: proc_macro::TokenStream, item: proc_macro::TokenStream) -> 
     let mut item = parse_macro_input!(item as ItemFn);
     let no_mangle = parse_quote!(#[no_mangle]);
     item.attrs.push(no_mangle);
-    let internal = parse_quote!(#[cfg_attr(any(target_arch="nvptx", target_arch="nvptx64"), nvvm_internal(kernel(#input)))]);
+    let internal = parse_quote!(#[cfg_attr(target_arch="nvptx64", nvvm_internal(kernel(#input)))]);
     item.attrs.push(internal);
 
     // used to guarantee some things about how params are passed in the codegen.
@@ -170,13 +170,13 @@ pub fn gpu_only(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -
     };
 
     let output = quote::quote! {
-        #[cfg(not(any(target_arch="nvptx", target_arch="nvptx64")))]
+        #[cfg(not(target_arch="nvptx64"))]
         #[allow(unused_variables)]
         #(#cloned_attrs)* #vis #sig_cpu {
             unimplemented!(concat!("`", stringify!(#fn_name), "` can only be used on the GPU with rustc_codegen_nvvm"))
         }
 
-        #[cfg(any(target_arch="nvptx", target_arch="nvptx64"))]
+        #[cfg(target_arch="nvptx64")]
         #(#attrs)* #vis #sig {
             #block
         }


### PR DESCRIPTION
32-bit support was removed in [ef4fcc86d](https://github.com/Rust-GPU/Rust-CUDA/commit/ef4fcc86d46fc7237991ed7ae5e2c8d4b26ad0e7). Updates attributes to match. Fixes numerous warnings when compiling with newer nightly.