### PR TITLE
Updated crates to use new versions of Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
 [workspace]
+
+resolver = "2"
+
 members = [
   "crates/*",
   "crates/optix/examples/ex*",

--- a/crates/blastoff/Cargo.toml
+++ b/crates/blastoff/Cargo.toml
@@ -6,11 +6,11 @@ authors = ["Riccardo D'Ambrosio <rdambrosio016@gmail.com>"]
 repository = "https://github.com/Rust-GPU/Rust-CUDA"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.8"
 cublas_sys = { version = "0.1", path = "../cublas_sys" }
 cust = { version = "0.3", path = "../cust", features = ["impl_num_complex"] }
-num-complex = "0.4.0"
-half = { version = "1.8.0", optional = true }
+num-complex = "0.4.6"
+half = { version = "2.4.1", optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]

--- a/crates/cuda_builder/Cargo.toml
+++ b/crates/cuda_builder/Cargo.toml
@@ -11,6 +11,6 @@ readme = "../../README.md"
 [dependencies]
 rustc_codegen_nvvm = { version = "0.3", path = "../rustc_codegen_nvvm" }
 nvvm = { path = "../nvvm", version = "0.1" }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
 find_cuda_helper = { version = "0.2", path = "../find_cuda_helper" }

--- a/crates/cuda_std/Cargo.toml
+++ b/crates/cuda_std/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/Rust-GPU/Rust-CUDA"
 readme = "../../README.md"
 
 [dependencies]
-vek = { version = "0.15.1", default-features = false, features = ["libm"] }
+vek = { version = "0.17.1", default-features = false, features = ["libm"] }
 cuda_std_macros = { version = "0.2", path = "../cuda_std_macros" }
-half = "1.7.1"
-bitflags = "1.3.2"
-paste = "1.0.5"
+half = "2.4.1"
+bitflags = "2.8"
+paste = "1.0.15"

--- a/crates/cuda_std_macros/Cargo.toml
+++ b/crates/cuda_std_macros/Cargo.toml
@@ -11,6 +11,6 @@ readme = "../../README.md"
 proc-macro = true
 
 [dependencies]
-quote = "1.0.9"
-syn = { version = "1.0.75", features = ["full"] }
-proc-macro2 = "1"
+quote = "1.0.38"
+syn = { version = "2.0.96", features = ["full"] }
+proc-macro2 = "1.0.93"

--- a/crates/cuda_std_macros/src/lib.rs
+++ b/crates/cuda_std_macros/src/lib.rs
@@ -156,7 +156,7 @@ pub fn gpu_only(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -
 
     let mut cloned_attrs = attrs.clone();
     cloned_attrs.retain(|a| {
-        !a.path
+        !a.path()
             .get_ident()
             .map(|x| *x == "nvvm_internal")
             .unwrap_or_default()
@@ -199,7 +199,7 @@ pub fn externally_visible(
     let mut func = syn::parse_macro_input!(item as syn::ItemFn);
 
     assert!(
-        func.attrs.iter().any(|a| a.path.is_ident("no_mangle")),
+        func.attrs.iter().any(|a| a.path().is_ident("no_mangle")),
         "#[externally_visible] function should also be #[no_mangle]"
     );
 

--- a/crates/cudnn/Cargo.toml
+++ b/crates/cudnn/Cargo.toml
@@ -5,5 +5,5 @@ name = "cudnn"
 version = "0.1.0"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.8"
 cust = {version = "0.3.2", path = "../cust"}

--- a/crates/cust/Cargo.toml
+++ b/crates/cust/Cargo.toml
@@ -15,13 +15,13 @@ readme = "../../README.md"
 [dependencies]
 cust_core = { path = "../cust_core", version = "0.1.0"}
 cust_raw = { path = "../cust_raw", version = "0.11.2"}
-bitflags = "1.2"
+bitflags = "2.8"
 cust_derive = { path = "../cust_derive", version = "0.2" }
-glam = { version = "0.20", features=["cuda"], optional = true }
+glam = { version = "0.29.2", features=["cuda"], optional = true }
 mint = { version = "^0.5", optional = true }
-num-complex = { version = "0.4", optional = true }
-vek = { version = "0.15.1", optional = true, default-features = false }
-bytemuck = { version = "1.7.3", optional = true }
+num-complex = { version = "0.4.6", optional = true }
+vek = { version = "0.17.1", optional = true, default-features = false }
+bytemuck = { version = "1.21", optional = true }
 
 [features]
 default= ["bytemuck", "impl_glam", "impl_mint", "impl_vek"]

--- a/crates/cust/src/graph.rs
+++ b/crates/cust/src/graph.rs
@@ -320,7 +320,7 @@ impl Graph {
         let mut raw = MaybeUninit::uninit();
 
         unsafe {
-            cuda::cuGraphCreate(raw.as_mut_ptr(), flags.bits).to_result()?;
+            cuda::cuGraphCreate(raw.as_mut_ptr(), flags.bits()).to_result()?;
 
             Ok(Self {
                 raw: raw.assume_init(),

--- a/crates/cust/src/memory/array.rs
+++ b/crates/cust/src/memory/array.rs
@@ -155,7 +155,7 @@ impl ArrayFormat {
 
 bitflags::bitflags! {
     /// Flags which modify the behavior of CUDA array creation.
-    #[derive(Default)]
+    #[derive(Default, Debug, PartialEq)]
     pub struct ArrayObjectFlags: c_uint {
         /// Enables creation of layered CUDA arrays. When this flag is set, depth specifies the
         /// number of layers, not the depth of a 3D array.

--- a/crates/cust/src/texture.rs
+++ b/crates/cust/src/texture.rs
@@ -41,7 +41,7 @@ pub enum TextureFilterMode {
 
 bitflags::bitflags! {
     /// Flags which modify the behavior of CUDA texture creation.
-    #[derive(Default)]
+    #[derive(Default, Debug, Clone, Copy)]
     pub struct TextureDescriptorFlags: c_uint {
         /// Suppresses the default behavior of having the texture promote data to floating point data in the range
         /// of [0, 1]. This flag does nothing if the texture is a texture of `u32`s.
@@ -306,7 +306,7 @@ impl ResourceViewDescriptor {
 
 bitflags::bitflags! {
     /// Flags for a resource descriptor. Currently empty.
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     pub struct ResourceDescriptorFlags: c_uint {
         #[doc(hidden)]
         const _ZERO = 0;

--- a/crates/cust_core/Cargo.toml
+++ b/crates/cust_core/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/Rust-GPU/Rust-CUDA"
 readme = "../../README.md"
 
 [dependencies]
-vek = { version = "0.15.1", default-features=false, features=["libm"], optional = true }
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false, optional=true }
+vek = { version = "0.17.1", default-features=false, features=["libm"], optional = true }
+glam = { version = "0.29.2", features=["cuda", "libm"], default-features=false, optional=true }
 mint = { version = "^0.5", optional = true }
-half = { version = "1.8", optional = true }
-num-complex = { version = "0.4", optional = true }
+half = { version = "2.4.1", optional = true }
+num-complex = { version = "0.4.6", optional = true }
 cust_derive = { path = "../cust_derive", version = "0.2" }

--- a/crates/cust_derive/Cargo.toml
+++ b/crates/cust_derive/Cargo.toml
@@ -12,6 +12,6 @@ readme = "../../README.md"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = "2.0.96"
+quote = "1.0.38"
+proc-macro2 = "1.0.93"

--- a/crates/gpu_rand/Cargo.toml
+++ b/crates/gpu_rand/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Rust-GPU/Rust-CUDA"
 readme = "../../README.md"
 
 [dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "0.9" }
 cust_core = { version = "0.1.0", path = "../cust_core" }
 
 [target.'cfg(target_os = "cuda")'.dependencies]

--- a/crates/optix/Cargo.toml
+++ b/crates/optix/Cargo.toml
@@ -19,11 +19,11 @@ impl_half=["cust/impl_half", "half"]
 cust = { version = "0.3", path = "../cust", features=["impl_mint"] }
 cust_raw = { version = "0.11.2", path = "../cust_raw" }
 cfg-if = "1.0.0"
-bitflags = "1.3.2"
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false, optional=true }
-half = { version = "^1.8", optional = true }
-memoffset = "0.6.4"
-mint = "0.5.8"
+bitflags = "2.8"
+glam = { version = "0.29", features=["cuda", "libm"], default-features=false, optional=true }
+half = { version = "2.4.1", optional = true }
+memoffset = "0.9.1"
+mint = "0.5.9"
 embed-doc-image = {version = "0.1.4"}
 
 [build-dependencies]

--- a/crates/optix_device/Cargo.toml
+++ b/crates/optix_device/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 authors = ["Anders Langlands <anderslanglands@gmail.com>", "Riccardo D'Ambrosio <rdambrosio016@gmail.com>"]
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.8"
 cuda_std = { version = "0.2", path = "../cuda_std" }
-glam = { version = "0.20", features=["cuda", "libm"], default-features=false }
-paste = "1.0.6"
-seq-macro = "0.3.0"
+glam = { version = "0.29", features=["cuda", "libm"], default-features=false }
+paste = "1.0.15"
+seq-macro = "0.3.5"
 cust_core = { version = "0.1", path = "../cust_core" }

--- a/crates/optix_device/src/transform.rs
+++ b/crates/optix_device/src/transform.rs
@@ -96,6 +96,7 @@ fn matrix_motion_transform_from_handle_ptr(
 bitflags::bitflags! {
     /// Possible motion flags.
     #[repr(transparent)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct MotionFlags: u32 {
         const START_VANISH = 1 << 0;
         const END_VANISH   = 1 << 1;

--- a/crates/optix_device_macros/Cargo.toml
+++ b/crates/optix_device_macros/Cargo.toml
@@ -11,6 +11,6 @@ readme = "../../README.md"
 proc-macro = true
 
 [dependencies]
-quote = "1.0.9"
-syn = { version = "1.0.75", features = ["full"] }
-proc-macro2 = "1"
+quote = "1.0.38"
+syn = { version = "2.0.96", features = ["full"] }
+proc-macro2 = "1.0.93"

--- a/crates/ptx/Cargo.toml
+++ b/crates/ptx/Cargo.toml
@@ -10,5 +10,5 @@ readme = "../../README.md"
 [dependencies]
 ascii = "1"
 # used for lexing/serializing very large enums of instructions/opcodes
-strum = { version = "0.21", features = ["derive"] }
-smallvec = "1.7"
+strum = { version = "0.26.3", features = ["derive"] }
+smallvec = "1.13.2"

--- a/crates/rustc_codegen_nvvm/Cargo.toml
+++ b/crates/rustc_codegen_nvvm/Cargo.toml
@@ -16,14 +16,14 @@ crate-type = ["dylib"]
 
 [dependencies]
 nvvm = { version = "0.1", path = "../nvvm" }
-rustc-demangle = "0.1.20"
-libc = "0.2.97"
-tar = "0.4.35"
-once_cell = "1.8.0"
-bitflags = "1.3.2"
-tracing = { version = "0.1.29", features = ["release_max_level_debug"] }
+rustc-demangle = "0.1.24"
+libc = "0.2.169"
+tar = "0.4.43"
+once_cell = "1.8.0" # this can be replaced wit std::cell implementation 
+bitflags = "2.8"
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 find_cuda_helper = { version = "0.2", path = "../find_cuda_helper" }
-tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 rustc_codegen_nvvm_macros = { version = "0.1", path = "../rustc_codegen_nvvm_macros" }
 
 [build-dependencies]

--- a/crates/rustc_codegen_nvvm/Cargo.toml
+++ b/crates/rustc_codegen_nvvm/Cargo.toml
@@ -19,7 +19,6 @@ nvvm = { version = "0.1", path = "../nvvm" }
 rustc-demangle = "0.1.24"
 libc = "0.2.169"
 tar = "0.4.43"
-once_cell = "1.8.0" # this can be replaced wit std::cell implementation 
 bitflags = "2.8"
 tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 find_cuda_helper = { version = "0.2", path = "../find_cuda_helper" }

--- a/crates/rustc_codegen_nvvm_macros/Cargo.toml
+++ b/crates/rustc_codegen_nvvm_macros/Cargo.toml
@@ -11,6 +11,6 @@ readme = "../../README.md"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.81", features = ["full"] }
-quote = "1.0.10"
-proc-macro2 = "1.0.32"
+syn = { version = "2.0.96", features = ["full"] }
+quote = "1.0.38"
+proc-macro2 = "1.0.93"

--- a/examples/cuda/cpu/add/Cargo.toml
+++ b/examples/cuda/cpu/add/Cargo.toml
@@ -12,12 +12,12 @@ nanorand = "0.6.1"
 # the newest semver compatible versions anyway.
 log = "=0.4.17"
 regex-syntax = "=0.6.28"
-regex = "=1.7.1"
+regex = "=1.11.1"
 thread_local = "=1.1.4"
 jobserver = "=0.1.25"
 cc = "=1.0.78"
-rayon = "=1.5.1"
-rayon-core = "=1.10.0"
+rayon = "=1.10"
+rayon-core = "=1.12.1"
 byteorder = "=1.4.0"
 
 [build-dependencies]

--- a/examples/cuda/cpu/path_tracer/Cargo.toml
+++ b/examples/cuda/cpu/path_tracer/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-vek = { version = "0.15", features = ["bytemuck", "mint"] }
-bytemuck = { version = "1.7.2", features = ["derive"] }
+vek = { version = "0.17.1", features = ["bytemuck", "mint"] }
+bytemuck = { version = "1.21", features = ["derive"] }
 cust = { version = "0.3", path = "../../../../crates/cust", features = ["impl_vek"] }
-image = "0.23.14"
+image = "0.25.5"
 path_tracer_gpu = { path = "../../gpu/path_tracer_gpu" }
 gpu_rand = { version = "0.1", path = "../../../../crates/gpu_rand" }
 optix = { version = "0.1", path = "../../../../crates/optix" }
@@ -16,8 +16,8 @@ glutin = "0.27.0"
 imgui = "0.8.0"
 imgui-glium-renderer = "0.8.0"
 imgui-winit-support = "0.8.0"
-rayon = "1.5.1"
-sysinfo = "0.20.5"
+rayon = "1.10"
+sysinfo = "0.33.1"
 anyhow = "1.0.53"
 
 [build-dependencies]

--- a/examples/cuda/gpu/path_tracer_gpu/Cargo.toml
+++ b/examples/cuda/gpu/path_tracer_gpu/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 cuda_std = { version = "0.2", path = "../../../../crates/cuda_std" }
-enum_dispatch = "0.3.7"
+enum_dispatch = "0.3.13"
 gpu_rand = { version = "0.1", path = "../../../../crates/gpu_rand" }
 cust_core = { path = "../../../../crates/cust_core" }
 optix_device = { path = "../../../../crates/optix_device" }

--- a/examples/optix/denoiser/Cargo.toml
+++ b/examples/optix/denoiser/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 optix = { version = "0.1", path = "../../../crates/optix" }
 structopt = "0.3"
 cust = { version = "0.3", path = "../../../crates/cust", features = ["impl_vek", "bytemuck"] }
-image = "0.23.14"
-vek = { version = "0.15.1", features = ["bytemuck"] }
+image = "0.25.5"
+vek = { version = "0.17.1", features = ["bytemuck"] }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,5 +5,5 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2021-12-04"
+channel = "nightly-2025-01-23"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,6 @@ license = "MIT"
 
 [dependencies]
 pico-args = "0.4.2"
-rayon = "1.5.1"
-regex = "1.3.9"
+rayon = "1.10"
+regex = "1.11.1"
 rustc_codegen_nvvm = { path = "../crates/rustc_codegen_nvvm" }


### PR DESCRIPTION
Most of the project builds and uses the newest version of all the dependencies. The only exception is the nvvm codegen crate which still doesn't build