### PR TITLE
Panic and emit error when `nvcc` can't be found by `which`

### DIFF
--- a/crates/find_cuda_helper/src/lib.rs
+++ b/crates/find_cuda_helper/src/lib.rs
@@ -157,10 +157,13 @@ fn detect_cuda_root_via_which_nvcc() -> PathBuf {
     let output = Command::new("which")
         .arg("nvcc")
         .output()
-        .expect("Command `which` must be available on *nix like systems.")
-        .stdout;
+        .expect("Command `which` must be available on *nix like systems.");
 
-    let path: PathBuf = String::from_utf8(output)
+    if !output.status.success() {
+        panic!("Couldn't find nvcc - `which nvcc` returned non-zero");
+    }
+
+    let path: PathBuf = String::from_utf8(output.stdout)
         .expect("Result must be valid UTF-8")
         .trim()
         .to_string()


### PR DESCRIPTION
[std::process::Command.output() ](https://doc.rust-lang.org/std/process/struct.Command.html#method.output)doesn't return error on non-zero exit, only when command.inner() fails.

If `which nvcc` can't find `nvcc` it returns like { ExitStatus(-1), "", "" } and causes a panic in the return of the function.

Instead, we should rather panic on non-zero return with an informational diagnostic message.

Seems like this can probably be lumped into PR #143 if we'd like to stuff one PR full of build fixes.
Let me know if we'd rather not panic here and I can see about adapting things to handle the null string.