### PR TITLE
Fixes to the Optix crate

### DIFF
--- a/crates/optix/src/acceleration.rs
+++ b/crates/optix/src/acceleration.rs
@@ -714,20 +714,20 @@ impl Default for BuildOperation {
     }
 }
 
+/// Configure how to handle ray times that are outside of the provided motion keys.
+///
+/// By default, the object will appear static (clamped) to the nearest motion
+/// key for rays outside of the range of key times.
+///
+/// * `START_VANISH` - The object will be invisible to rays with a time less
+/// than the first provided motion key
+/// * `END_VANISH` - The object will be invisible to rays with a time less
+/// than the first provided motion key
 #[derive(DeviceCopy, Clone, Copy, Debug, PartialEq)]
 pub struct MotionFlags(u16);
 
 bitflags::bitflags! {
-    /// Configure how to handle ray times that are outside of the provided motion keys.
-    ///
-    /// By default, the object will appear static (clamped) to the nearest motion
-    /// key for rays outside of the range of key times.
-    ///
-    /// * `START_VANISH` - The object will be invisible to rays with a time less
-    /// than the first provided motion key
-    /// * `END_VANISH` - The object will be invisible to rays with a time less
-    /// than the first provided motion key
-    impl MotionFlags: u16 {
+   impl MotionFlags: u16 {
         const NONE = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_NONE as u16;
         const START_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_START_VANISH as u16;
         const END_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_END_VANISH as u16;

--- a/crates/optix/src/acceleration.rs
+++ b/crates/optix/src/acceleration.rs
@@ -1560,7 +1560,6 @@ const_assert_eq!(
     std::mem::size_of::<sys::OptixInstance>()
 );
 
-
 #[derive(DeviceCopy, Clone, Copy, Debug)]
 pub struct InstanceFlags(OptixEnumBaseType);
 

--- a/crates/optix/src/acceleration.rs
+++ b/crates/optix/src/acceleration.rs
@@ -688,7 +688,7 @@ bitflags::bitflags! {
     /// an AH programs on the device. May affect the performance of the accel (seems to be larger).
     ///
     /// Note that `PREFER_FAST_TRACE` and `PREFER_FAST_BUILD` are mutually exclusive.
-    #[derive(Default)]
+    #[derive(Default, Clone, Copy, Debug, PartialEq)]
     pub struct BuildFlags: OptixEnumBaseType {
         const NONE = sys::OptixBuildFlags_OPTIX_BUILD_FLAG_NONE;
         const ALLOW_UPDATE = sys::OptixBuildFlags_OPTIX_BUILD_FLAG_ALLOW_UPDATE;
@@ -714,6 +714,9 @@ impl Default for BuildOperation {
     }
 }
 
+#[derive(DeviceCopy, Clone, Copy, Debug, PartialEq)]
+pub struct MotionFlags(u16);
+
 bitflags::bitflags! {
     /// Configure how to handle ray times that are outside of the provided motion keys.
     ///
@@ -724,8 +727,7 @@ bitflags::bitflags! {
     /// than the first provided motion key
     /// * `END_VANISH` - The object will be invisible to rays with a time less
     /// than the first provided motion key
-    #[derive(DeviceCopy)]
-    pub struct MotionFlags: u16 {
+    impl MotionFlags: u16 {
         const NONE = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_NONE as u16;
         const START_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_START_VANISH as u16;
         const END_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_END_VANISH as u16;
@@ -1558,9 +1560,12 @@ const_assert_eq!(
     std::mem::size_of::<sys::OptixInstance>()
 );
 
+
+#[derive(DeviceCopy, Clone, Copy, Debug)]
+pub struct InstanceFlags(OptixEnumBaseType);
+
 bitflags::bitflags! {
-    #[derive(DeviceCopy)]
-    pub struct InstanceFlags: OptixEnumBaseType {
+    impl InstanceFlags: OptixEnumBaseType {
         const NONE = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_NONE;
         const DISABLE_TRIANGLE_FACE_CULLING = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_DISABLE_TRIANGLE_FACE_CULLING;
         const FLIP_TRIANGLE_FACING = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_FLIP_TRIANGLE_FACING;
@@ -1684,7 +1689,7 @@ pub struct InstancePointerArray<'i> {
 }
 
 impl<'i> InstancePointerArray<'i> {
-    pub fn new(instances: &'i DeviceSlice<CUdeviceptr>) -> InstancePointerArray {
+    pub fn new(instances: &'i DeviceSlice<CUdeviceptr>) -> InstancePointerArray<'i> {
         InstancePointerArray { instances }
     }
 }

--- a/crates/optix/src/pipeline.rs
+++ b/crates/optix/src/pipeline.rs
@@ -208,7 +208,7 @@ cfg_if::cfg_if! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Clone, Copy, Debug, PartialEq, Hash)]
     pub struct TraversableGraphFlags: OptixEnumBaseType {
         const ALLOW_ANY = sys::OptixTraversableGraphFlags::OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_ANY;
         const ALLOW_SINGLE_GAS = sys::OptixTraversableGraphFlags::OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;
@@ -217,7 +217,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Clone, Copy, Debug, PartialEq, Hash)]
     pub struct ExceptionFlags: OptixEnumBaseType {
         const NONE = sys::OptixExceptionFlags::OPTIX_EXCEPTION_FLAG_NONE;
         const STACK_OVERFLOW = sys::OptixExceptionFlags::OPTIX_EXCEPTION_FLAG_STACK_OVERFLOW;
@@ -228,7 +228,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Clone, Copy, Debug, PartialEq, Hash)]
     pub struct PrimitiveTypeFlags: i32 {
         const DEFAULT = 0;
         const CUSTOM =  sys::OptixPrimitiveTypeFlags_OPTIX_PRIMITIVE_TYPE_FLAGS_CUSTOM;


### PR DESCRIPTION
Some new traits needed to be derived for MotionFlags, InstanceFlags, and some others. Additonally, from here: https://docs.rs/bitflags/latest/bitflags/,  it looks we need to use the impl syntax for the bit flag structs to work with the custom derive macros from cust.

Also fixed a warning about an elided lifetime