### PR TITLE
Partial fixes to optix crates and examples.

### DIFF
--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -4,6 +4,8 @@
 //! thread blocks and execute in SIMT fashion.
 
 use crate::gpu_only;
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use half::{bf16, f16};
 
 /// Synchronizes all of the threads inside of this warp according to `mask`.

--- a/crates/optix/Cargo.toml
+++ b/crates/optix/Cargo.toml
@@ -19,7 +19,7 @@ impl_half=["cust/impl_half", "half"]
 cust = { version = "0.3", path = "../cust", features=["impl_mint"] }
 cust_raw = { version = "0.11.2", path = "../cust_raw" }
 cfg-if = "1.0.0"
-bitflags = "2.8"
+bitflags = "2.9.0"
 glam = { version = "0.29", features=["cuda", "libm"], default-features=false, optional=true }
 half = { version = "2.4.1", optional = true }
 memoffset = "0.9.1"

--- a/crates/optix/src/acceleration.rs
+++ b/crates/optix/src/acceleration.rs
@@ -688,7 +688,7 @@ bitflags::bitflags! {
     /// an AH programs on the device. May affect the performance of the accel (seems to be larger).
     ///
     /// Note that `PREFER_FAST_TRACE` and `PREFER_FAST_BUILD` are mutually exclusive.
-    #[derive(Default)]
+    #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
     pub struct BuildFlags: OptixEnumBaseType {
         const NONE = sys::OptixBuildFlags_OPTIX_BUILD_FLAG_NONE;
         const ALLOW_UPDATE = sys::OptixBuildFlags_OPTIX_BUILD_FLAG_ALLOW_UPDATE;
@@ -714,18 +714,20 @@ impl Default for BuildOperation {
     }
 }
 
+/// Configure how to handle ray times that are outside of the provided motion keys.
+///
+/// By default, the object will appear static (clamped) to the nearest motion
+/// key for rays outside of the range of key times.
+///
+/// * `START_VANISH` - The object will be invisible to rays with a time less
+/// than the first provided motion key
+/// * `END_VANISH` - The object will be invisible to rays with a time less
+/// than the first provided motion key
+#[derive(DeviceCopy, Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MotionFlags(u16);
+
 bitflags::bitflags! {
-    /// Configure how to handle ray times that are outside of the provided motion keys.
-    ///
-    /// By default, the object will appear static (clamped) to the nearest motion
-    /// key for rays outside of the range of key times.
-    ///
-    /// * `START_VANISH` - The object will be invisible to rays with a time less
-    /// than the first provided motion key
-    /// * `END_VANISH` - The object will be invisible to rays with a time less
-    /// than the first provided motion key
-    #[derive(DeviceCopy)]
-    pub struct MotionFlags: u16 {
+   impl MotionFlags: u16 {
         const NONE = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_NONE as u16;
         const START_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_START_VANISH as u16;
         const END_VANISH = sys::OptixMotionFlags_OPTIX_MOTION_FLAG_END_VANISH as u16;
@@ -1558,9 +1560,10 @@ const_assert_eq!(
     std::mem::size_of::<sys::OptixInstance>()
 );
 
+#[derive(DeviceCopy, Clone, Copy, PartialEq, Eq, Debug)]
+pub struct InstanceFlags(OptixEnumBaseType);
 bitflags::bitflags! {
-    #[derive(DeviceCopy)]
-    pub struct InstanceFlags: OptixEnumBaseType {
+    impl InstanceFlags: OptixEnumBaseType {
         const NONE = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_NONE;
         const DISABLE_TRIANGLE_FACE_CULLING = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_DISABLE_TRIANGLE_FACE_CULLING;
         const FLIP_TRIANGLE_FACING = sys::OptixInstanceFlags_OPTIX_INSTANCE_FLAG_FLIP_TRIANGLE_FACING;

--- a/crates/optix/src/pipeline.rs
+++ b/crates/optix/src/pipeline.rs
@@ -208,7 +208,7 @@ cfg_if::cfg_if! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Hash, Clone, Copy, PartialEq, Eq, Debug)]
     pub struct TraversableGraphFlags: OptixEnumBaseType {
         const ALLOW_ANY = sys::OptixTraversableGraphFlags::OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_ANY;
         const ALLOW_SINGLE_GAS = sys::OptixTraversableGraphFlags::OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;
@@ -217,7 +217,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Hash, Clone, Copy, PartialEq, Eq, Debug)]
     pub struct ExceptionFlags: OptixEnumBaseType {
         const NONE = sys::OptixExceptionFlags::OPTIX_EXCEPTION_FLAG_NONE;
         const STACK_OVERFLOW = sys::OptixExceptionFlags::OPTIX_EXCEPTION_FLAG_STACK_OVERFLOW;
@@ -228,7 +228,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Hash, Clone, Copy, PartialEq, Eq, Debug)]
     pub struct PrimitiveTypeFlags: i32 {
         const DEFAULT = 0;
         const CUSTOM =  sys::OptixPrimitiveTypeFlags_OPTIX_PRIMITIVE_TYPE_FLAGS_CUSTOM;

--- a/crates/optix_device/src/hit.rs
+++ b/crates/optix_device/src/hit.rs
@@ -1,6 +1,7 @@
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 use glam::Vec3;
-
 /// The type of primitive that a ray hit.
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/optix_device/src/intersect.rs
+++ b/crates/optix_device/src/intersect.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 use paste::paste;
 use seq_macro::seq;

--- a/crates/optix_device/src/lib.rs
+++ b/crates/optix_device/src/lib.rs
@@ -1,9 +1,5 @@
-#![cfg_attr(
-    target_arch = "nvptx64",
-    no_std,
-    feature(asm_experimental_arch),
-    register_attr(nvvm_internal)
-)]
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 
 extern crate alloc;
 

--- a/crates/optix_device/src/misc.rs
+++ b/crates/optix_device/src/misc.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 
 /// Retrieves the data past the SBT header for this particular program

--- a/crates/optix_device/src/payload.rs
+++ b/crates/optix_device/src/payload.rs
@@ -1,4 +1,6 @@
 use crate::sys;
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 
 /// Overrides the payload for the given register to a value.

--- a/crates/optix_device/src/ray.rs
+++ b/crates/optix_device/src/ray.rs
@@ -1,4 +1,6 @@
 use crate::trace::*;
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 use glam::Vec3;
 

--- a/crates/optix_device/src/sys.rs
+++ b/crates/optix_device/src/sys.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::missing_safety_doc)]
 
 use crate::trace::{RayFlags, TraversableHandle};
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 use glam::Vec3;
 use paste::paste;

--- a/crates/optix_device/src/transform.rs
+++ b/crates/optix_device/src/transform.rs
@@ -1,4 +1,6 @@
 // use std::hint::unreachable_unchecked;
+#[cfg(target_os = "cuda")]
+use core::arch::asm;
 use cuda_std::gpu_only;
 use glam::{Vec3, Vec4};
 

--- a/examples/optix/denoiser/src/main.rs
+++ b/examples/optix/denoiser/src/main.rs
@@ -1,7 +1,7 @@
 use cust::memory::DeviceBuffer;
 use cust::prelude::{Stream, StreamFlags};
 use cust::util::SliceExt;
-use image::io::Reader;
+use image::ImageReader;
 use optix::context::DeviceContext;
 use optix::denoiser::{Denoiser, DenoiserModelKind, DenoiserParams, Image, ImageFormat};
 use std::error::Error;
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("input was not a file")
         .to_string_lossy()
         .to_string();
-    let img = Reader::open(opt.input)?.decode()?;
+    let img = ImageReader::open(opt.input)?.decode()?;
 
     let mut rgb = img.into_rgb8();
     let mut linear = vec![Vec3::<f32>::zero(); rgb.as_raw().len()];


### PR DESCRIPTION
These changes fixes errors when building `path_tracing_gpu`. It is now able to build and generate ptx. Also migrates a deprecated API in the `denoiser` example.

The host side still fails due to updated dependencies on its side.