### PR TITLE
Small Compatibility Fix for CUDA 12.8.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/nvvm.rs
+++ b/crates/rustc_codegen_nvvm/src/nvvm.rs
@@ -63,8 +63,8 @@ pub fn codegen_bitcode_modules(
     // make sure the nvvm version is high enough so users don't get confusing compilation errors.
     let (major, minor) = nvvm::ir_version();
 
-    if minor < 6 && major < 1 {
-        sess.dcx()
+    if major <= 1 && minor < 6 {
+            sess.dcx()
             .fatal("rustc_codegen_nvvm requires at least libnvvm 1.6 (CUDA 11.2)");
     }
 

--- a/crates/rustc_codegen_nvvm/src/nvvm.rs
+++ b/crates/rustc_codegen_nvvm/src/nvvm.rs
@@ -64,7 +64,7 @@ pub fn codegen_bitcode_modules(
     let (major, minor) = nvvm::ir_version();
 
     if major <= 1 && minor < 6 {
-            sess.dcx()
+        sess.dcx()
             .fatal("rustc_codegen_nvvm requires at least libnvvm 1.6 (CUDA 11.2)");
     }
 

--- a/crates/rustc_codegen_nvvm/src/nvvm.rs
+++ b/crates/rustc_codegen_nvvm/src/nvvm.rs
@@ -63,7 +63,7 @@ pub fn codegen_bitcode_modules(
     // make sure the nvvm version is high enough so users don't get confusing compilation errors.
     let (major, minor) = nvvm::ir_version();
 
-    if minor < 6 || major < 1 {
+    if minor < 6 && major < 1 {
         sess.dcx()
             .fatal("rustc_codegen_nvvm requires at least libnvvm 1.6 (CUDA 11.2)");
     }


### PR DESCRIPTION
The latest version of CUDA ships libnvvm with version 2.0, which fails the check for an appropriate version number. This commit fixes this so that 2.0 correctly passes the minimum version number check.

#163 Referencing this issue, this PR should provide a fix for that when using CUDA 12.8