### PR TITLE
Turn off local CUDA install cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           cuda: ${{ matrix.cuda }}
           linux-local-args: ${{ toJson(matrix.linux-local-args) }}
+          use-local-cache: false
 
       - name: Verify CUDA installation
         run: nvcc --version


### PR DESCRIPTION
This will hopefully remove running out of disk space flakiness, see https://github.com/Jimver/cuda-toolkit/issues/386