### PR TITLE
chore(example): add nvvm library path to LD_LIBRARY_PATH and add back the `add` example in CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Clippy
         env:
           RUSTFLAGS: -Dwarnings
-        run: cargo clippy --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "add" --exclude "ex*" --exclude "cudnn*"
+        run: cargo clippy --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*"
       - name: Build
-        run: cargo build --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "add" --exclude "ex*" --exclude "cudnn*"
+        run: cargo build --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*"
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -Dwarnings
-        run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "add" --exclude "ex*" --exclude "cudnn*" --exclude "cust_raw"
+        run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*" --exclude "cust_raw"

--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -38,5 +38,8 @@ WORKDIR /data/Rust-CUDA
 RUN rustup show
 RUN rm -f "rust-toolchain.toml"
 
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu22-cuda11/Dockerfile
+++ b/container/ubuntu22-cuda11/Dockerfile
@@ -40,5 +40,8 @@ WORKDIR /data/Rust-CUDA
 RUN rustup show
 RUN rm -f "rust-toolchain.toml"
 
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu22-cuda12/Dockerfile
+++ b/container/ubuntu22-cuda12/Dockerfile
@@ -40,5 +40,8 @@ WORKDIR /data/Rust-CUDA
 RUN rustup show
 RUN rm -f "rust-toolchain.toml"
 
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu24-cuda12/Dockerfile
+++ b/container/ubuntu24-cuda12/Dockerfile
@@ -41,5 +41,8 @@ WORKDIR /data/Rust-CUDA
 RUN rustup show
 RUN rm -f "rust-toolchain.toml"
 
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info


### PR DESCRIPTION
When linking `libnvvm.so.4` into `librustc_codegen_nvvm.so` shared library via the `cust_raw` package, we specified the following parameters in the `build.rs`:

- cargo::rustc-link-search=native=xxx
- cargo::rustc-link-lib=dylib=nvvm

According to the [Cargo documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-search), the path we added to the `rustc-link-search` parameter is not further populated to the `LD_LIBRARY_PATH` for search by the transitive dependencies.

> These paths are also added to the dynamic library search path environment variable if they are within the OUT_DIR.

The behavior is intended to be limited to the OUT_DIR so the `libnvvm.so.4`, which lives as a part of the CUDA SDK, is excluded. Therefore, we must add it to the LD_LIBRARY_PATH manually in our container build stage.

----

Since this PR changes the container, we would need to retrigger a container build manully before we can see correct CI results.

Resolves #129.