### PR TITLE
refactor(container): reduce layers and image size. Add `.devcontainer.json` sample.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "image" : "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest",
+  // Uncoment the following lines to use a Dockerfile instead of a prebuilt image.
+  // "build": {
+  //   "dockerfile": "${localWorkspaceFolder}/container/ubuntu24-cuda12/Dockerfile",
+  //   "context": "${localWorkspaceFolder}"
+  // },
+  "containerEnv": {
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
+  },
+  "runArgs": ["--runtime=nvidia", "--gpus", "all"],
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ book
 /target
 Cargo.lock
 **/.vscode
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>The Rust CUDA Project</h1>
 
   <p>
-    <strong>An ecosystem of libraries and tools for writing and executing extremely fast GPU code fully in 
+    <strong>An ecosystem of libraries and tools for writing and executing extremely fast GPU code fully in
     <a href="https://www.rust-lang.org/">Rust</a></strong>
   </p>
 
@@ -13,7 +13,7 @@
     <span> | </span>
     <a href="guide/src/features.md">Features</a>
   </h3>
-<strong>⚠️ The project is still in early development, expect bugs, safety issues, and things that don't work ⚠️</strong> 
+<strong>⚠️ The project is still in early development, expect bugs, safety issues, and things that don't work ⚠️</strong>
 </div>
 
 <br/>
@@ -94,12 +94,14 @@ cargo build
 
 ## Use Rust-CUDA in Container Environments
 
+The distribution related Dockerfile are located in `container` folder.
+Taking ubuntu 24.04 as an example, run the following command in repository root:
 ```bash
-# The distribution related Dockerfile are located in `container` folder.
-# Taking ubuntu 24.04 as an example, run the following command in repository root:
 docker build -f ./container/ubuntu24/Dockerfile -t rust-cuda-ubuntu24 .
 docker run --rm --runtime=nvidia --gpus all -it rust-cuda-ubuntu24
 ```
+
+A sample `.devcontainer.json` file is also included, configured for Ubuntu 24.02. Copy this to `.devcontainer/devcontainer.json` to make additonal customizations.
 
 ## License
 

--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -7,7 +7,8 @@ RUN dnf -y install \
     redhat-rpm-config \
     which \
     xz \
-    zlib-devel
+    zlib-devel && \
+    dnf clean all
 
 # Needed to build `path_tracer`, `optix/ex03_window` example
 RUN dnf -y install \
@@ -16,30 +17,31 @@ RUN dnf -y install \
     libX11-devel  \
     libXcursor-devel \
     libXi-devel \
-    libXrandr-devel
+    libXrandr-devel && \
+    dnf clean all
 
 # Get LLVM 7 & libffi.so.6
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/l/libffi3.1-3.1-36.el9.x86_64.rpm
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-7.0.1-7.el8.x86_64.rpm
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-devel-7.0.1-7.el8.x86_64.rpm
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-libs-7.0.1-7.el8.x86_64.rpm
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-static-7.0.1-7.el8.x86_64.rpm
-RUN dnf -y install ./*.rpm
-RUN ln -s /usr/bin/llvm-config-7-64 /usr/bin/llvm-config
+RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/l/libffi3.1-3.1-36.el9.x86_64.rpm && \
+    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-7.0.1-7.el8.x86_64.rpm && \
+    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-devel-7.0.1-7.el8.x86_64.rpm && \
+    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-libs-7.0.1-7.el8.x86_64.rpm && \
+    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-static-7.0.1-7.el8.x86_64.rpm && \
+    dnf -y install ./*.rpm && \
+    ln -s /usr/bin/llvm-config-7-64 /usr/bin/llvm-config && \
+    rm -rf ./*.rpm && \
+    dnf clean all
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Setup the workspace
-ADD ./rust-toolchain.toml /data/Rust-CUDA/
 WORKDIR /data/Rust-CUDA
-RUN rustup show
-RUN rm -f "rust-toolchain.toml"
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-toolchain.toml \
+    rustup show
 
 # Add nvvm to LD_LIBRARY_PATH.
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
-
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu22-cuda11/Dockerfile
+++ b/container/ubuntu22-cuda11/Dockerfile
@@ -1,7 +1,6 @@
 FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     build-essential \
     curl \
     clang \
@@ -9,39 +8,41 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     libtinfo-dev \
     pkg-config \
     xz-utils \
-    zlib1g-dev
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Needed to build `path_tracer`, `optix/ex03_window` example
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     cmake \
     libfontconfig-dev \
     libx11-xcb-dev \
     libxcursor-dev \
     libxi-dev \
     libxinerama-dev \
-    libxrandr-dev
+    libxrandr-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb
-RUN apt-get install -y ./*.deb
-RUN ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config
+RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
+    apt-get update && apt-get install -y ./*.deb && \
+    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
+    rm -rf ./*.deb && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Setup the workspace
-ADD ./rust-toolchain.toml /data/Rust-CUDA/
 WORKDIR /data/Rust-CUDA
-RUN rustup show
-RUN rm -f "rust-toolchain.toml"
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-toolchain.toml \
+    rustup show
 
 # Add nvvm to LD_LIBRARY_PATH.
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
-
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu22-cuda12/Dockerfile
+++ b/container/ubuntu22-cuda12/Dockerfile
@@ -1,7 +1,6 @@
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     build-essential \
     curl \
     clang \
@@ -9,39 +8,41 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     libtinfo-dev \
     pkg-config \
     xz-utils \
-    zlib1g-dev
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Needed to build `path_tracer`, `optix/ex03_window` example
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     cmake \
     libfontconfig-dev \
     libx11-xcb-dev \
     libxcursor-dev \
     libxi-dev \
     libxinerama-dev \
-    libxrandr-dev
+    libxrandr-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb
-RUN apt-get install -y ./*.deb
-RUN ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config
+RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
+    apt-get update && apt-get install -y ./*.deb && \
+    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
+    rm -rf ./*.deb && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Setup the workspace
-ADD ./rust-toolchain.toml /data/Rust-CUDA/
 WORKDIR /data/Rust-CUDA
-RUN rustup show
-RUN rm -f "rust-toolchain.toml"
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-toolchain.toml \
+    rustup show
 
 # Add nvvm to LD_LIBRARY_PATH.
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
-
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/container/ubuntu24-cuda12/Dockerfile
+++ b/container/ubuntu24-cuda12/Dockerfile
@@ -1,7 +1,6 @@
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     build-essential \
     clang \
     curl \
@@ -9,40 +8,42 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     libtinfo-dev \
     pkg-config \
     xz-utils \
-    zlib1g-dev
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Needed to build `path_tracer`, `optix/ex03_window` example
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     cmake \
     libfontconfig-dev \
     libx11-xcb-dev \
     libxcursor-dev \
     libxi-dev \
     libxinerama-dev \
-    libxrandr-dev
+    libxrandr-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get LLVM 7 & libffi7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://security.ubuntu.com/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb
-RUN apt-get install -y ./*.deb
-RUN ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config
+RUN curl -sSf -L -O http://security.ubuntu.com/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
+    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
+    apt-get install -y ./*.deb && \
+    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
+    rm -rf ./*.deb && \
+    rm -rf /var/lib/apt/lists/*
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Setup the workspace
-ADD ./rust-toolchain.toml /data/Rust-CUDA/
 WORKDIR /data/Rust-CUDA
-RUN rustup show
-RUN rm -f "rust-toolchain.toml"
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-toolchain.toml \
+    rustup show
 
 # Add nvvm to LD_LIBRARY_PATH.
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
-
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-03-02"
-components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt"]
+components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
- Combines the RUN commands to reduce image layers where possible.
- Clean apt/dnf package cache, remove downloaded package files,
- Temporally mount `rust-toolchain.toml` when installing rust.
- Add a sample `.devcontainer.json`, configured with our ubuntu24 image, with NVidia gpus and capabilities set, and includes git. Users can copy this to `.devcontainer/devcontainer.json` to make additional changes.