### PR TITLE
refactor(nvvm): Remove `cust_raw` as a codegen dependency.

### DIFF
--- a/crates/nvvm/src/lib.rs
+++ b/crates/nvvm/src/lib.rs
@@ -10,6 +10,8 @@ use std::{
 
 use cust_raw::nvvm_sys;
 
+pub use cust_raw::nvvm_sys::LIBDEVICE_BITCODE;
+
 /// Get the major and minor NVVM IR version.
 pub fn ir_version() -> (i32, i32) {
     unsafe {

--- a/crates/rustc_codegen_nvvm/Cargo.toml
+++ b/crates/rustc_codegen_nvvm/Cargo.toml
@@ -15,7 +15,6 @@ readme = "../../README.md"
 crate-type = ["dylib"]
 
 [dependencies]
-cust_raw = { path = "../cust_raw" }
 nvvm = { version = "0.1", path = "../nvvm" }
 rustc-demangle = "0.1.24"
 libc = "0.2.169"

--- a/crates/rustc_codegen_nvvm/src/nvvm.rs
+++ b/crates/rustc_codegen_nvvm/src/nvvm.rs
@@ -6,7 +6,6 @@ use crate::common::AsCCharPtr;
 use crate::context::CodegenArgs;
 use crate::llvm::*;
 use crate::lto::ThinBuffer;
-use cust_raw::nvvm_sys;
 use nvvm::*;
 use rustc_codegen_ssa::traits::ThinBufferMethods;
 use rustc_session::{Session, config::DebugInfo};
@@ -105,7 +104,7 @@ pub fn codegen_bitcode_modules(
     let buf = ThinBuffer::new(module);
 
     prog.add_module(buf.data(), "merged".to_string())?;
-    prog.add_lazy_module(nvvm_sys::LIBDEVICE_BITCODE, "libdevice".to_string())?;
+    prog.add_lazy_module(LIBDEVICE_BITCODE, "libdevice".to_string())?;
     prog.add_lazy_module(LIBINTRINSICS, "libintrinsics".to_string())?;
 
     // for now, while the codegen is young, we always run verification on the program.


### PR DESCRIPTION
Codegen only needs `nvvm`, which itself take `cust_raw` as a dependency. It currently depends on `cust_raw` so that it can import libdevice bytecode from  `cust_raw::nvvm_sys`. With this change, `nvvm` now exports libdevice bytecode from `cust_raw::nvvm_sys`, and removes `cust_raw` as a codegen dependency.