### PR TITLE
refactor(cust_raw): Add `must_use` attrbuites on result/error types.

### DIFF
--- a/crates/blastoff/src/context.rs
+++ b/crates/blastoff/src/context.rs
@@ -340,7 +340,7 @@ impl CublasContext {
 impl Drop for CublasContext {
     fn drop(&mut self) {
         unsafe {
-            cublas_sys::cublasDestroy(self.raw);
+            let _ = cublas_sys::cublasDestroy(self.raw);
         }
     }
 }

--- a/crates/cust/src/context/legacy.rs
+++ b/crates/cust/src/context/legacy.rs
@@ -372,7 +372,7 @@ impl Drop for Context {
 
         unsafe {
             let inner = mem::replace(&mut self.inner, ptr::null_mut());
-            driver_sys::cuCtxDestroy(inner);
+            let _ = driver_sys::cuCtxDestroy(inner);
         }
     }
 }

--- a/crates/cust/src/context/mod.rs
+++ b/crates/cust/src/context/mod.rs
@@ -197,7 +197,7 @@ impl Context {
             driver_sys::cuDevicePrimaryCtxRetain(inner.as_mut_ptr(), device.as_raw())
                 .to_result()?;
             let inner = inner.assume_init();
-            driver_sys::cuCtxSetCurrent(inner);
+            driver_sys::cuCtxSetCurrent(inner).to_result()?;
             Ok(Self {
                 inner,
                 device: device.as_raw(),
@@ -316,7 +316,7 @@ impl Drop for Context {
 
         unsafe {
             self.inner = ptr::null_mut();
-            driver_sys::cuDevicePrimaryCtxRelease(self.device);
+            let _ = driver_sys::cuDevicePrimaryCtxRelease(self.device);
         }
     }
 }

--- a/crates/cust/src/event.rs
+++ b/crates/cust/src/event.rs
@@ -347,7 +347,9 @@ impl Event {
 
 impl Drop for Event {
     fn drop(&mut self) {
-        unsafe { cuEventDestroy(self.0) };
+        unsafe {
+            let _ = cuEventDestroy(self.0);
+        };
     }
 }
 

--- a/crates/cust/src/link.rs
+++ b/crates/cust/src/link.rs
@@ -137,6 +137,8 @@ impl Linker {
 
 impl Drop for Linker {
     fn drop(&mut self) {
-        unsafe { driver_sys::cuLinkDestroy(self.raw) };
+        unsafe {
+            let _ = driver_sys::cuLinkDestroy(self.raw);
+        };
     }
 }

--- a/crates/cust/src/memory/array.rs
+++ b/crates/cust/src/memory/array.rs
@@ -867,7 +867,9 @@ impl std::fmt::Debug for ArrayObject {
 
 impl Drop for ArrayObject {
     fn drop(&mut self) {
-        unsafe { driver_sys::cuArrayDestroy(self.handle) };
+        unsafe {
+            let _ = driver_sys::cuArrayDestroy(self.handle);
+        };
     }
 }
 

--- a/crates/cust/src/module.rs
+++ b/crates/cust/src/module.rs
@@ -491,7 +491,7 @@ impl Drop for Module {
         unsafe {
             // No choice but to panic if this fails...
             let module = mem::replace(&mut self.inner, ptr::null_mut());
-            driver_sys::cuModuleUnload(module);
+            let _ = driver_sys::cuModuleUnload(module);
         }
     }
 }

--- a/crates/cust/src/stream.rs
+++ b/crates/cust/src/stream.rs
@@ -344,7 +344,7 @@ impl Drop for Stream {
         unsafe {
             let inner = mem::replace(&mut self.inner, ptr::null_mut());
 
-            driver_sys::cuStreamDestroy(inner);
+            let _ = driver_sys::cuStreamDestroy(inner);
         }
     }
 }

--- a/crates/cust/src/surface.rs
+++ b/crates/cust/src/surface.rs
@@ -30,7 +30,7 @@ impl Drop for Surface {
                 }
             }
 
-            cuSurfObjectDestroy(self.handle);
+            let _ = cuSurfObjectDestroy(self.handle);
         }
     }
 }

--- a/crates/cust/src/texture.rs
+++ b/crates/cust/src/texture.rs
@@ -415,7 +415,7 @@ impl Drop for Texture {
                 }
             }
 
-            cuTexObjectDestroy(self.handle);
+            let _ = cuTexObjectDestroy(self.handle);
         }
     }
 }

--- a/crates/cust_raw/build/main.rs
+++ b/crates/cust_raw/build/main.rs
@@ -111,6 +111,7 @@ fn create_cuda_driver_bindings(sdk: &cuda_sdk::CudaSdk, outdir: &path::Path) {
         .derive_ord(true)
         .size_t_is_usize(true)
         .layout_tests(true)
+        .must_use_type("CUresult")
         .generate()
         .expect("Unable to generate CUDA driver bindings.");
     bindings
@@ -152,6 +153,7 @@ fn create_cuda_runtime_bindings(sdk: &cuda_sdk::CudaSdk, outdir: &path::Path) {
         .derive_ord(true)
         .size_t_is_usize(true)
         .layout_tests(true)
+        .must_use_type("cudaError_t")
         .generate()
         .expect("Unable to generate CUDA runtime bindings.");
     bindings
@@ -198,6 +200,7 @@ fn create_cublas_bindings(sdk: &cuda_sdk::CudaSdk, outdir: &path::Path) {
             .derive_ord(true)
             .size_t_is_usize(true)
             .layout_tests(true)
+            .must_use_type("cublasStatus_t")
             .generate()
             .unwrap_or_else(|_| panic!("Unable to generate {pkg} bindings."));
         bindings
@@ -231,6 +234,7 @@ fn create_nptx_compiler_bindings(sdk: &cuda_sdk::CudaSdk, outdir: &path::Path) {
         .derive_ord(true)
         .size_t_is_usize(true)
         .layout_tests(true)
+        .must_use_type("nvPTXCompileResult")
         .generate()
         .expect("Unable to generate nvptx-compiler bindings.");
     bindings
@@ -261,6 +265,7 @@ fn create_nvvm_bindings(sdk: &cuda_sdk::CudaSdk, outdir: &path::Path) {
         .derive_ord(true)
         .size_t_is_usize(true)
         .layout_tests(true)
+        .must_use_type("nvvmResult")
         .generate()
         .expect("Unable to generate libNVVM bindings.");
     bindings

--- a/crates/nvvm/src/lib.rs
+++ b/crates/nvvm/src/lib.rs
@@ -18,7 +18,7 @@ pub fn ir_version() -> (i32, i32) {
         let mut major_dbg = MaybeUninit::uninit();
         let mut minor_dbg = MaybeUninit::uninit();
         // according to the docs this cant fail
-        nvvm_sys::nvvmIRVersion(
+        let _ = nvvm_sys::nvvmIRVersion(
             major_ir.as_mut_ptr(),
             minor_ir.as_mut_ptr(),
             major_dbg.as_mut_ptr(),
@@ -36,7 +36,7 @@ pub fn dbg_version() -> (i32, i32) {
         let mut major_dbg = MaybeUninit::uninit();
         let mut minor_dbg = MaybeUninit::uninit();
         // according to the docs this cant fail
-        nvvm_sys::nvvmIRVersion(
+        let _ = nvvm_sys::nvvmIRVersion(
             major_ir.as_mut_ptr(),
             minor_ir.as_mut_ptr(),
             major_dbg.as_mut_ptr(),
@@ -52,7 +52,7 @@ pub fn nvvm_version() -> (i32, i32) {
         let mut major = MaybeUninit::uninit();
         let mut minor = MaybeUninit::uninit();
         // according to the docs this cant fail
-        nvvm_sys::nvvmVersion(major.as_mut_ptr(), minor.as_mut_ptr());
+        let _ = nvvm_sys::nvvmVersion(major.as_mut_ptr(), minor.as_mut_ptr());
         (major.assume_init(), minor.assume_init())
     }
 }


### PR DESCRIPTION
CUDA libraries have different result types (`CUresult`, `cudaError_t`, etc.) that must be checked after calling the function. This change adds `must_use` attribute on those types and functions that return that type when generating the bindings. This also fixes the warnings caused by this in places where the result type was not checked by either checking the result type, or ignore the value.