### PR TITLE
Rename and retitle rust workflow to be windows workflow

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,4 +1,4 @@
-name: Rust CI
+name: CI on Windows
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ env:
 
 jobs:
   rust:
-    name: Rust on ${{ matrix.os }} with CUDA ${{ matrix.cuda }}
+    name: ${{ matrix.os }}/CUDA-${{ matrix.cuda }}
     runs-on: ${{ matrix.os }}
     env:
       LLVM_LINK_STATIC: 1


### PR DESCRIPTION
We now have a different workflow for linux, so let's make this clearer.