### PR TITLE
Scaffolding for running tests in CI 

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -38,17 +38,24 @@ jobs:
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
           - name: RockyLinux-9/CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
+    outputs:
+      # Output the result of the permission check
+      actor_has_write_permission: ${{ steps.permission_check.outputs.has-permission }}
+      # Output the buile artifact details so the test job can use them
+      artifact_name: ${{ steps.artifact_details.outputs.name }}
+      artifact_path: ${{ steps.artifact_details.outputs.path }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Debug Info
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Author Association: ${{ github.event.pull_request.author_association }}"
-          echo "Is Owner/Member?: ${{ contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association) }}"
+      - name: Check if triggering actor has write permission
+        id: permission_check
+        uses: scherermichael-oss/action-has-permission@v1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify CUDA, Rust installation
         run: |
@@ -57,7 +64,6 @@ jobs:
       - name: Load Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          # Use the specific commit SHA for the most accurate build cache key
           key: ${{ matrix.variance.name }}-${{ github.sha }}
 
       - name: Rustfmt
@@ -79,39 +85,38 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*" --exclude "cust_raw"
 
-      - name: Set artifact name
-        id: artifact_name
+      - name: Prepare artifact details
+        id: artifact_details
         run: |
-          ARTIFACT_NAME="target_debug-$(echo '${{ matrix.variance.name }}' | sed 's/\//-/g')-${{ github.run_id }}"
-          echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          SANITIZED_NAME=$(echo '${{ matrix.variance.name }}' | sed 's/[^a-zA-Z0-9.-]/-/g')
+          ARTIFACT_NAME="target_debug-${SANITIZED_NAME}-${{ github.run_id }}"
+          ARTIFACT_PATH="target/debug" # Define the path consistently
+          echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          echo "path=${ARTIFACT_PATH}" >> $GITHUB_OUTPUT # Output the path variable
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.artifact_name.outputs.artifact_name }}
-          path: target/debug
+          name: ${{ steps.artifact_details.outputs.name }}
+          path: ${{ steps.artifact_details.outputs.path }}
           retention-days: 1
-
 
   test:
     name: ${{ matrix.variance.name }}
-    # This job depends on the build job completing successfully for the same matrix entry
+    # Depends on the build job
     needs: build
-    # Run this job ONLY IF:
-    # - The build job succeeded
-    # - AND EITHER:
-    #   - The event was a push to the 'main' branch
-    #   - OR The event was a manual trigger
-    #   - OR The event was a pull_request AND the author is an OWNER or MEMBER of the repo
+    # Run ONLY IF:
+    # - The corresponding 'build' job succeeded AND
+    # - EITHER:
+    #   - Event is 'push' to 'main'
+    #   - OR Event is 'workflow_dispatch'
+    #   - OR Event is 'pull_request' AND the 'actor_has_write_permission' output from build is 'true'
     if: >
       needs.build.result == 'success' &&
       (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         github.event_name == 'workflow_dispatch' ||
-        (
-          github.event_name == 'pull_request' &&
-          contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
-        )
+        (github.event_name == 'pull_request' && needs.build.outputs.actor_has_write_permission == 'true')
       )
     runs-on: ubuntu-latest
     # Use the exact same container image as the build job
@@ -123,8 +128,8 @@ jobs:
       matrix:
         variance:
           # Must match the build job's matrix definition
-          # - name: Ubuntu-22.04/CUDA-11.8.0
-          #   image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda11:latest"
+          # - name: Ubuntu-22.04/CUDA-11.8.0 image:
+          #   "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda11:latest"
           - name: Ubuntu-22.04/CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
           - name: Ubuntu-24.04/CUDA-12.8.1
@@ -132,26 +137,19 @@ jobs:
           - name: RockyLinux-9/CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
     steps:
-      - name: Set artifact name
-        id: artifact_name
-        run: |
-          ARTIFACT_NAME="target_debug-$(echo '${{ matrix.variance.name }}' | sed 's/\//-/g')-${{ github.run_id }}"
-          echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
-
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ steps.artifact_name.outputs.artifact_name }}
-          path: target/debug
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ${{ needs.build.outputs.artifact_path }}
 
       - name: List downloaded files
-        run: ls -lR target/debug
+        run: ls -lR ${{ needs.build.outputs.artifact_path }}
 
       - name: Run remote tests
         env:
           # Inject the id and secret ONLY in this job, which is conditionally run
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # Add any other env vars needed for testing
         run: |
           echo "Stubbed out"

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -90,13 +90,13 @@ jobs:
     # This job depends on the build job completing successfully for the same matrix entry
     needs: build
     # Run this job ONLY IF:
-    # - The build job succeeded ('needs.build.result == 'success'')
+    # - The build job succeeded
     # - AND EITHER:
     #   - The event was a push to the 'main' branch
     #   - OR The event was a manual trigger
     #   - OR The event was a pull_request AND the author is an OWNER or MEMBER of the repo
     if: >
-      always() && needs.build.result == 'success' &&
+      needs.build.result == 'success' &&
       (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Debug Info
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Author Association: ${{ github.event.pull_request.author_association }}"
+          echo "Is Owner/Member?: ${{ contains(fromJson('["OWNER", "MEMBER"]'), github.event.pull_request.author_association) }}"
+
       - name: Verify CUDA, Rust installation
         run: |
           nvcc --version
@@ -85,12 +92,6 @@ jobs:
           path: target/debug
           retention-days: 1
 
-      - name: Debug Info
-        if: github.event_name == 'pull_request'
-        run: |
-            echo "Event Name: ${{ github.event_name }}"
-            echo "Author Association: ${{ github.event.pull_request.author_association }}"
-            echo "Is Owner/Member?: ${{ contains(fromJson('[\"OWNER\", \"MEMBER\"]'), github.event.pull_request.author_association) }}"
 
   test:
     name: ${{ matrix.variance.name }}

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check if triggering actor has write permission
         id: permission_check
-        uses: scherermichael-oss/action-has-permission@v1
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
         with:
           required-permission: write
         env:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.variance.name }}
+    name: Build/${{ matrix.variance.name }}
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.variance.image }}
@@ -103,7 +103,7 @@ jobs:
           retention-days: 1
 
   test:
-    name: ${{ matrix.variance.name || 'Tests' }}
+    name: Test/${{ matrix.variance.name }}
     # Depends on the build job
     needs: build
     # Run ONLY IF:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -85,6 +85,13 @@ jobs:
           path: target/debug
           retention-days: 1
 
+      - name: Debug Info
+        if: github.event_name == 'pull_request'
+        run: |
+            echo "Event Name: ${{ github.event_name }}"
+            echo "Author Association: ${{ github.event.pull_request.author_association }}"
+            echo "Is Owner/Member?: ${{ contains(fromJson('[\"OWNER\", \"MEMBER\"]'), github.event.pull_request.author_association) }}"
+
   test:
     name: ${{ matrix.variance.name }}
     # This job depends on the build job completing successfully for the same matrix entry

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -72,24 +72,28 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*" --exclude "cust_raw"
 
+      - name: Set artifact name
+        id: artifact_name
+        run: |
+          ARTIFACT_NAME="target_debug-$(echo '${{ matrix.variance.name }}' | sed 's/\//-/g')-${{ github.run_id }}"
+          echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          # Use github.run_id for a unique name per workflow run
-          name: target_debug-${{ matrix.variance.name }}-${{ github.run_id }}
-          path: |
-            target/debug
+          name: ${{ steps.artifact_name.outputs.artifact_name }}
+          path: target/debug
           retention-days: 1
 
-  test-remote:
-    name: Test ${{ matrix.variance.name }}
+  test:
+    name: ${{ matrix.variance.name }}
     # This job depends on the build job completing successfully for the same matrix entry
     needs: build
     # Run this job ONLY IF:
     # - The build job succeeded ('needs.build.result == 'success'')
     # - AND EITHER:
     #   - The event was a push to the 'main' branch
-    #   - OR The event was a manual trigger 
+    #   - OR The event was a manual trigger
     #   - OR The event was a pull_request AND the author is an OWNER or MEMBER of the repo
     if: >
       always() && needs.build.result == 'success' &&
@@ -120,11 +124,16 @@ jobs:
           - name: RockyLinux-9/CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
     steps:
+      - name: Set artifact name
+        id: artifact_name
+        run: |
+          ARTIFACT_NAME="target_debug-$(echo '${{ matrix.variance.name }}' | sed 's/\//-/g')-${{ github.run_id }}"
+          echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          # Match the unique artifact name from the build job using the workflow run_id
-          name: target_debug-${{ matrix.variance.name }}-${{ github.run_id }}
+          name: ${{ steps.artifact_name.outputs.artifact_name }}
           path: target/debug
 
       - name: List downloaded files

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -90,9 +90,9 @@ jobs:
         run: |
           SANITIZED_NAME=$(echo '${{ matrix.variance.name }}' | sed 's/[^a-zA-Z0-9.-]/-/g')
           ARTIFACT_NAME="target_debug-${SANITIZED_NAME}-${{ github.run_id }}"
-          ARTIFACT_PATH="target/debug" # Define the path consistently
+          ARTIFACT_PATH="target/debug"
           echo "name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
-          echo "path=${ARTIFACT_PATH}" >> $GITHUB_OUTPUT # Output the path variable
+          echo "path=${ARTIFACT_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -102,7 +102,7 @@ jobs:
           retention-days: 1
 
   test:
-    name: ${{ matrix.variance.name }}
+    name: ${{ matrix.variance.name || 'Tests' }}
     # Depends on the build job
     needs: build
     # Run ONLY IF:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,15 +1,25 @@
 name: CI on Linux
 
 on:
+  # Trigger builds on pull requests
   pull_request:
     paths-ignore:
       - "**.md"
+
+  # Trigger builds AND tests on push to main
   push:
+    branches:
+      - main
     paths-ignore:
       - "**.md"
+
+  # Add manual trigger via Actions UI for running BOTH build and test
+  workflow_dispatch:
+
 env:
   RUST_LOG: info
   RUST_BACKTRACE: 1
+
 jobs:
   build:
     name: ${{ matrix.variance.name }}
@@ -28,9 +38,11 @@ jobs:
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
           - name: RockyLinux-9/CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Verify CUDA, Rust installation
         run: |
           nvcc --version
@@ -38,18 +50,91 @@ jobs:
       - name: Load Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.variance.name }}
+          # Use the specific commit SHA for the most accurate build cache key
+          key: ${{ matrix.variance.name }}-${{ github.sha }}
+
       - name: Rustfmt
         run: cargo fmt --all -- --check
+
       - name: Clippy
         env:
           RUSTFLAGS: -Dwarnings
         run: cargo clippy --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*"
+
       - name: Build all bindings
         run: cargo build --all-features -p cust_raw
-      - name: Build
+
+      - name: Build workspace
         run: cargo build --workspace --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*"
+
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "optix*" --exclude "path_tracer" --exclude "denoiser" --exclude "ex*" --exclude "cudnn*" --exclude "cust_raw"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          # Use github.run_id for a unique name per workflow run
+          name: target_debug-${{ matrix.variance.name }}-${{ github.run_id }}
+          path: |
+            target/debug
+          retention-days: 1
+
+  test-remote:
+    name: Test ${{ matrix.variance.name }}
+    # This job depends on the build job completing successfully for the same matrix entry
+    needs: build
+    # Run this job ONLY IF:
+    # - The build job succeeded ('needs.build.result == 'success'')
+    # - AND EITHER:
+    #   - The event was a push to the 'main' branch
+    #   - OR The event was a manual trigger 
+    #   - OR The event was a pull_request AND the author is an OWNER or MEMBER of the repo
+    if: >
+      always() && needs.build.result == 'success' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(fromJson('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
+        )
+      )
+    runs-on: ubuntu-latest
+    # Use the exact same container image as the build job
+    container:
+      image: ${{ matrix.variance.image }}
+    strategy:
+      # Save some credits
+      fail-fast: true
+      matrix:
+        variance:
+          # Must match the build job's matrix definition
+          # - name: Ubuntu-22.04/CUDA-11.8.0
+          #   image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda11:latest"
+          - name: Ubuntu-22.04/CUDA-12.8.1
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
+          - name: Ubuntu-24.04/CUDA-12.8.1
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
+          - name: RockyLinux-9/CUDA-12.8.1
+            image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Match the unique artifact name from the build job using the workflow run_id
+          name: target_debug-${{ matrix.variance.name }}-${{ github.run_id }}
+          path: target/debug
+
+      - name: List downloaded files
+        run: ls -lR target/debug
+
+      - name: Run remote tests
+        env:
+          # Inject the id and secret ONLY in this job, which is conditionally run
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Add any other env vars needed for testing
+        run: |
+          echo "Stubbed out"

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -120,10 +120,6 @@ jobs:
         (github.event_name == 'pull_request' && needs.build.outputs.actor_has_write_permission == 'true')
       )
     runs-on: ubuntu-latest
-    env:
-      # Inject the id and secret ONLY in this job, which is conditionally run
-      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
     # Use the exact same container image as the build job
     container:
       image: ${{ matrix.variance.image }}

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -40,7 +40,7 @@ jobs:
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
     outputs:
       # Output the result of the permission check
-      actor_has_write_permission: ${{ steps.permission_check.outputs.has-permission }}
+      actor_has_write_permission: ${{ steps.check_access.outputs.require-result }}
       # Output the buile artifact details so the test job can use them
       artifact_name: ${{ steps.artifact_details.outputs.name }}
       artifact_path: ${{ steps.artifact_details.outputs.path }}
@@ -49,11 +49,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check if triggering actor has write permission
-        id: permission_check
-        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+      - name: Check access permissions
+        id: check_access
+        uses: actions-cool/check-user-permission@v2
         with:
-          required-permission: write
+          require: write
+          username: ${{ github.triggering_actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       # Output the result of the permission check
       actor_has_write_permission: ${{ steps.check_access.outputs.require-result }}
-      # Output the buile artifact details so the test job can use them
+      # Output the build artifact details so the test job can use them
       artifact_name: ${{ steps.artifact_details.outputs.name }}
       artifact_path: ${{ steps.artifact_details.outputs.path }}
 

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    name: Build/${{ matrix.variance.name }}
+    name: Build / ${{ matrix.variance.name }}
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.variance.image }}
@@ -32,11 +32,11 @@ jobs:
         variance:
           # - name: Ubuntu-22.04/CUDA-11.8.0
           #   image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda11:latest"
-          - name: Ubuntu-22.04/CUDA-12.8.1
+          - name: Ubuntu-22.04 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-          - name: Ubuntu-24.04/CUDA-12.8.1
+          - name: Ubuntu-24.04 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
-          - name: RockyLinux-9/CUDA-12.8.1
+          - name: RockyLinux-9 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
     outputs:
       # Output the result of the permission check
@@ -103,7 +103,7 @@ jobs:
           retention-days: 1
 
   test:
-    name: Test/${{ matrix.variance.name }}
+    name: Test / ${{ matrix.variance.name }}
     # Depends on the build job
     needs: build
     # Run ONLY IF:
@@ -120,6 +120,10 @@ jobs:
         (github.event_name == 'pull_request' && needs.build.outputs.actor_has_write_permission == 'true')
       )
     runs-on: ubuntu-latest
+    env:
+      # Inject the id and secret ONLY in this job, which is conditionally run
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
     # Use the exact same container image as the build job
     container:
       image: ${{ matrix.variance.image }}
@@ -129,13 +133,13 @@ jobs:
       matrix:
         variance:
           # Must match the build job's matrix definition
-          # - name: Ubuntu-22.04/CUDA-11.8.0 image:
+          # - name: Ubuntu-22.04 / CUDA-11.8.0 image:
           #   "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda11:latest"
-          - name: Ubuntu-22.04/CUDA-12.8.1
+          - name: Ubuntu-22.04 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-          - name: Ubuntu-24.04/CUDA-12.8.1
+          - name: Ubuntu-24.04 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
-          - name: RockyLinux-9/CUDA-12.8.1
+          - name: RockyLinux-9 / CUDA-12.8.1
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
     steps:
       - name: Download build artifacts
@@ -149,7 +153,6 @@ jobs:
 
       - name: Run remote tests
         env:
-          # Inject the id and secret ONLY in this job, which is conditionally run
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   rust:
-    name: ${{ matrix.os }}/CUDA-${{ matrix.cuda }}
+    name: Build/${{ matrix.os }}/CUDA-${{ matrix.cuda }}
     runs-on: ${{ matrix.os }}
     env:
       LLVM_LINK_STATIC: 1

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   rust:
-    name: Build/${{ matrix.os }}/CUDA-${{ matrix.cuda }}
+    name: Build / ${{ matrix.os }} / CUDA-${{ matrix.cuda }}
     runs-on: ${{ matrix.os }}
     env:
       LLVM_LINK_STATIC: 1


### PR DESCRIPTION
I'm breaking up adding tests in CI so it doesn't get too big.

This is the scaffolding, it doesn't actually run any tests.

The reason for a different step is to gate tests so that secrets are not exposed on pull requests. Maintainers PRs and main get tests run automatically, but other wise the step is skipped (but can be trigger manually, once this is landed on main).