### PR TITLE
reactor(cust_raw): Generate bindings for cuda types and restructure `cust_raw`'s crates

### DIFF
--- a/crates/blastoff/src/context.rs
+++ b/crates/blastoff/src/context.rs
@@ -4,8 +4,8 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use cust::stream::Stream;
-use cust_raw::cublas_sys;
-use cust_raw::driver_sys;
+use cust_raw::cublas;
+use cust_raw::driver;
 
 use super::error::DropResult;
 use super::error::ToResult as _;
@@ -73,7 +73,7 @@ bitflags::bitflags! {
 /// - [Matrix Multiplication <span style="float:right;">`gemm`</span>](CublasContext::gemm)
 #[derive(Debug)]
 pub struct CublasContext {
-    pub(crate) raw: cublas_sys::cublasHandle_t,
+    pub(crate) raw: cublas::cublasHandle_t,
 }
 
 impl CublasContext {
@@ -92,10 +92,10 @@ impl CublasContext {
     pub fn new() -> Result<Self> {
         let mut raw = MaybeUninit::uninit();
         unsafe {
-            cublas_sys::cublasCreate(raw.as_mut_ptr()).to_result()?;
-            cublas_sys::cublasSetPointerMode(
+            cublas::cublasCreate(raw.as_mut_ptr()).to_result()?;
+            cublas::cublasSetPointerMode(
                 raw.assume_init(),
-                cublas_sys::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+                cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
             )
             .to_result()?;
             Ok(Self {
@@ -112,7 +112,7 @@ impl CublasContext {
 
         unsafe {
             let inner = mem::replace(&mut ctx.raw, ptr::null_mut());
-            match cublas_sys::cublasDestroy(inner).to_result() {
+            match cublas::cublasDestroy(inner).to_result() {
                 Ok(()) => {
                     mem::forget(ctx);
                     Ok(())
@@ -127,7 +127,7 @@ impl CublasContext {
         let mut raw = MaybeUninit::<u32>::uninit();
         unsafe {
             // getVersion can't fail
-            cublas_sys::cublasGetVersion(self.raw, raw.as_mut_ptr().cast())
+            cublas::cublasGetVersion(self.raw, raw.as_mut_ptr().cast())
                 .to_result()
                 .unwrap();
 
@@ -145,17 +145,15 @@ impl CublasContext {
     ) -> Result<T> {
         unsafe {
             // cudaStream_t is the same as CUstream
-            cublas_sys::cublasSetStream(
+            cublas::cublasSetStream(
                 self.raw,
-                mem::transmute::<*mut driver_sys::CUstream_st, *mut cublas_sys::CUstream_st>(
-                    stream.as_inner(),
-                ),
+                mem::transmute::<driver::CUstream, cublas::cudaStream_t>(stream.as_inner()),
             )
             .to_result()?;
             let res = func(self)?;
             // reset the stream back to NULL just in case someone calls with_stream, then drops the stream, and tries to
             // execute a raw sys function with the context's handle.
-            cublas_sys::cublasSetStream(self.raw, ptr::null_mut()).to_result()?;
+            cublas::cublasSetStream(self.raw, ptr::null_mut()).to_result()?;
             Ok(res)
         }
     }
@@ -185,12 +183,12 @@ impl CublasContext {
     /// ```
     pub fn set_atomics_mode(&self, allowed: bool) -> Result<()> {
         unsafe {
-            Ok(cublas_sys::cublasSetAtomicsMode(
+            Ok(cublas::cublasSetAtomicsMode(
                 self.raw,
                 if allowed {
-                    cublas_sys::cublasAtomicsMode_t::CUBLAS_ATOMICS_ALLOWED
+                    cublas::cublasAtomicsMode_t::CUBLAS_ATOMICS_ALLOWED
                 } else {
-                    cublas_sys::cublasAtomicsMode_t::CUBLAS_ATOMICS_NOT_ALLOWED
+                    cublas::cublasAtomicsMode_t::CUBLAS_ATOMICS_NOT_ALLOWED
                 },
             )
             .to_result()?)
@@ -215,10 +213,10 @@ impl CublasContext {
     pub fn get_atomics_mode(&self) -> Result<bool> {
         let mut mode = MaybeUninit::uninit();
         unsafe {
-            cublas_sys::cublasGetAtomicsMode(self.raw, mode.as_mut_ptr()).to_result()?;
+            cublas::cublasGetAtomicsMode(self.raw, mode.as_mut_ptr()).to_result()?;
             Ok(match mode.assume_init() {
-                cublas_sys::cublasAtomicsMode_t::CUBLAS_ATOMICS_ALLOWED => true,
-                cublas_sys::cublasAtomicsMode_t::CUBLAS_ATOMICS_NOT_ALLOWED => false,
+                cublas::cublasAtomicsMode_t::CUBLAS_ATOMICS_ALLOWED => true,
+                cublas::cublasAtomicsMode_t::CUBLAS_ATOMICS_NOT_ALLOWED => false,
             })
         }
     }
@@ -238,9 +236,9 @@ impl CublasContext {
     /// ```
     pub fn set_math_mode(&self, math_mode: MathMode) -> Result<()> {
         unsafe {
-            Ok(cublas_sys::cublasSetMathMode(
+            Ok(cublas::cublasSetMathMode(
                 self.raw,
-                mem::transmute::<u32, cublas_sys::cublasMath_t>(math_mode.bits()),
+                mem::transmute::<u32, cublas::cublasMath_t>(math_mode.bits()),
             )
             .to_result()?)
         }
@@ -263,7 +261,7 @@ impl CublasContext {
     pub fn get_math_mode(&self) -> Result<MathMode> {
         let mut mode = MaybeUninit::uninit();
         unsafe {
-            cublas_sys::cublasGetMathMode(self.raw, mode.as_mut_ptr()).to_result()?;
+            cublas::cublasGetMathMode(self.raw, mode.as_mut_ptr()).to_result()?;
             Ok(MathMode::from_bits(mode.assume_init() as u32)
                 .expect("Invalid MathMode from cuBLAS"))
         }
@@ -303,7 +301,7 @@ impl CublasContext {
             let path = log_file_name.map(|p| CString::new(p).expect("nul in log_file_name"));
             let path_ptr = path.map_or(ptr::null(), |s| s.as_ptr());
 
-            cublas_sys::cublasLoggerConfigure(
+            cublas::cublasLoggerConfigure(
                 enable as i32,
                 log_to_stdout as i32,
                 log_to_stderr as i32,
@@ -320,7 +318,7 @@ impl CublasContext {
     ///
     /// The callback must not panic and unwind.
     pub unsafe fn set_logger_callback(callback: Option<unsafe extern "C" fn(*const c_char)>) {
-        cublas_sys::cublasSetLoggerCallback(callback)
+        cublas::cublasSetLoggerCallback(callback)
             .to_result()
             .unwrap();
     }
@@ -329,7 +327,7 @@ impl CublasContext {
     pub fn get_logger_callback() -> Option<unsafe extern "C" fn(*const c_char)> {
         let mut cb = MaybeUninit::uninit();
         unsafe {
-            cublas_sys::cublasGetLoggerCallback(cb.as_mut_ptr())
+            cublas::cublasGetLoggerCallback(cb.as_mut_ptr())
                 .to_result()
                 .unwrap();
             cb.assume_init()
@@ -340,7 +338,7 @@ impl CublasContext {
 impl Drop for CublasContext {
     fn drop(&mut self) {
         unsafe {
-            let _ = cublas_sys::cublasDestroy(self.raw);
+            let _ = cublas::cublasDestroy(self.raw);
         }
     }
 }

--- a/crates/blastoff/src/error.rs
+++ b/crates/blastoff/src/error.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CStr, fmt::Display};
 
 use cust::error::CudaError;
-use cust_raw::cublas_sys;
+use cust_raw::cublas;
 
 /// Result that contains the un-dropped value on error.
 pub type DropResult<T> = std::result::Result<(), (CublasError, T)>;
@@ -25,7 +25,7 @@ impl std::error::Error for CublasError {}
 impl Display for CublasError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
-            let ptr = cublas_sys::cublasGetStatusString(self.into_raw());
+            let ptr = cublas::cublasGetStatusString(self.into_raw());
             let cow = CStr::from_ptr(ptr).to_string_lossy();
             f.write_str(cow.as_ref())
         }
@@ -36,9 +36,9 @@ pub trait ToResult {
     fn to_result(self) -> Result<(), CublasError>;
 }
 
-impl ToResult for cublas_sys::cublasStatus_t {
+impl ToResult for cublas::cublasStatus_t {
     fn to_result(self) -> Result<(), CublasError> {
-        use cust_raw::cublas_sys::cublasStatus_t::*;
+        use cust_raw::cublas::cublasStatus_t::*;
         use CublasError::*;
 
         Err(match self {
@@ -57,8 +57,8 @@ impl ToResult for cublas_sys::cublasStatus_t {
 }
 
 impl CublasError {
-    pub fn into_raw(self) -> cublas_sys::cublasStatus_t {
-        use cust_raw::cublas_sys::cublasStatus_t::*;
+    pub fn into_raw(self) -> cublas::cublasStatus_t {
+        use cust_raw::cublas::cublasStatus_t::*;
         use CublasError::*;
 
         match self {

--- a/crates/blastoff/src/lib.rs
+++ b/crates/blastoff/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-pub use cust_raw::cublas_sys;
+pub use cust_raw::cublas;
 use num_complex::{Complex32, Complex64};
 
 pub use context::*;
@@ -39,34 +39,34 @@ pub trait BlasDatatype: private::Sealed + cust::memory::DeviceCopy {
     /// The corresponding float type. For complex numbers this means their backing
     /// precision, and for floats it is just themselves.
     type FloatTy: Float;
-    fn to_raw(&self) -> cublas_sys::cudaDataType;
+    fn to_raw(&self) -> cublas::cudaDataType;
 }
 
 impl BlasDatatype for f32 {
     type FloatTy = f32;
-    fn to_raw(&self) -> cublas_sys::cudaDataType {
-        cublas_sys::cudaDataType::CUDA_R_32F
+    fn to_raw(&self) -> cublas::cudaDataType {
+        cublas::cudaDataType::CUDA_R_32F
     }
 }
 
 impl BlasDatatype for f64 {
     type FloatTy = f64;
-    fn to_raw(&self) -> cublas_sys::cudaDataType {
-        cublas_sys::cudaDataType::CUDA_R_64F
+    fn to_raw(&self) -> cublas::cudaDataType {
+        cublas::cudaDataType::CUDA_R_64F
     }
 }
 
 impl BlasDatatype for Complex32 {
     type FloatTy = f32;
-    fn to_raw(&self) -> cublas_sys::cudaDataType {
-        cublas_sys::cudaDataType::CUDA_C_32F
+    fn to_raw(&self) -> cublas::cudaDataType {
+        cublas::cudaDataType::CUDA_C_32F
     }
 }
 
 impl BlasDatatype for Complex64 {
     type FloatTy = f64;
-    fn to_raw(&self) -> cublas_sys::cudaDataType {
-        cublas_sys::cudaDataType::CUDA_C_64F
+    fn to_raw(&self) -> cublas::cudaDataType {
+        cublas::cudaDataType::CUDA_C_64F
     }
 }
 
@@ -106,11 +106,11 @@ pub enum MatrixOp {
 
 impl MatrixOp {
     /// Returns the corresponding `cublasOperation_t` for this operation.
-    pub fn to_raw(self) -> cublas_sys::cublasOperation_t {
+    pub fn to_raw(self) -> cublas::cublasOperation_t {
         match self {
-            MatrixOp::None => cublas_sys::cublasOperation_t::CUBLAS_OP_N,
-            MatrixOp::Transpose => cublas_sys::cublasOperation_t::CUBLAS_OP_T,
-            MatrixOp::ConjugateTranspose => cublas_sys::cublasOperation_t::CUBLAS_OP_C,
+            MatrixOp::None => cublas::cublasOperation_t::CUBLAS_OP_N,
+            MatrixOp::Transpose => cublas::cublasOperation_t::CUBLAS_OP_T,
+            MatrixOp::ConjugateTranspose => cublas::cublasOperation_t::CUBLAS_OP_C,
         }
     }
 }

--- a/crates/blastoff/src/raw/level1.rs
+++ b/crates/blastoff/src/raw/level1.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_int;
 
-use cust_raw::cublas_sys::*;
+use cust_raw::cublas::*;
 use num_complex::{Complex32, Complex64};
 
 use crate::BlasDatatype;

--- a/crates/blastoff/src/raw/level3.rs
+++ b/crates/blastoff/src/raw/level3.rs
@@ -1,6 +1,6 @@
 use std::os::raw::c_int;
 
-use cust_raw::cublas_sys::*;
+use cust_raw::cublas::*;
 use num_complex::{Complex32, Complex64};
 
 use crate::GemmDatatype;

--- a/crates/cust/src/context/legacy.rs
+++ b/crates/cust/src/context/legacy.rs
@@ -118,8 +118,8 @@ use std::mem;
 use std::mem::transmute;
 use std::ptr;
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::CUcontext;
+use cust_raw::driver;
+use cust_raw::driver::CUcontext;
 
 use crate::context::ContextHandle;
 use crate::device::Device;
@@ -262,7 +262,7 @@ impl Context {
             // lifetime guarantees so we create-and-push, then pop, then the programmer has to
             // push again.
             let mut ctx: CUcontext = ptr::null_mut();
-            driver_sys::cuCtxCreate(&mut ctx as *mut CUcontext, flags.bits(), device.as_raw())
+            driver::cuCtxCreate(&mut ctx as *mut CUcontext, flags.bits(), device.as_raw())
                 .to_result()?;
             Ok(Context { inner: ctx })
         }
@@ -290,7 +290,7 @@ impl Context {
     pub fn get_api_version(&self) -> CudaResult<CudaApiVersion> {
         unsafe {
             let mut api_version = 0u32;
-            driver_sys::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
+            driver::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
             Ok(CudaApiVersion {
                 version: api_version as i32,
             })
@@ -354,7 +354,7 @@ impl Context {
 
         unsafe {
             let inner = mem::replace(&mut ctx.inner, ptr::null_mut());
-            match driver_sys::cuCtxDestroy(inner).to_result() {
+            match driver::cuCtxDestroy(inner).to_result() {
                 Ok(()) => {
                     mem::forget(ctx);
                     Ok(())
@@ -372,7 +372,7 @@ impl Drop for Context {
 
         unsafe {
             let inner = mem::replace(&mut self.inner, ptr::null_mut());
-            let _ = driver_sys::cuCtxDestroy(inner);
+            let _ = driver::cuCtxDestroy(inner);
         }
     }
 }
@@ -422,7 +422,7 @@ impl UnownedContext {
     pub fn get_api_version(&self) -> CudaResult<CudaApiVersion> {
         unsafe {
             let mut api_version = 0u32;
-            driver_sys::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
+            driver::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
             Ok(CudaApiVersion {
                 version: api_version as i32,
             })
@@ -456,7 +456,7 @@ impl ContextStack {
     pub fn pop() -> CudaResult<UnownedContext> {
         unsafe {
             let mut ctx: CUcontext = ptr::null_mut();
-            driver_sys::cuCtxPopCurrent(&mut ctx as *mut CUcontext).to_result()?;
+            driver::cuCtxPopCurrent(&mut ctx as *mut CUcontext).to_result()?;
             Ok(UnownedContext { inner: ctx })
         }
     }
@@ -481,7 +481,7 @@ impl ContextStack {
     /// ```
     pub fn push<C: ContextHandle>(ctx: &C) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxPushCurrent(ctx.get_inner()).to_result()?;
+            driver::cuCtxPushCurrent(ctx.get_inner()).to_result()?;
             Ok(())
         }
     }
@@ -528,8 +528,8 @@ impl CurrentContext {
     pub fn get_cache_config() -> CudaResult<CacheConfig> {
         unsafe {
             let mut config = CacheConfig::PreferNone;
-            driver_sys::cuCtxGetCacheConfig(
-                &mut config as *mut CacheConfig as *mut driver_sys::CUfunc_cache,
+            driver::cuCtxGetCacheConfig(
+                &mut config as *mut CacheConfig as *mut driver::CUfunc_cache,
             )
             .to_result()?;
             Ok(config)
@@ -556,8 +556,7 @@ impl CurrentContext {
     pub fn get_device() -> CudaResult<Device> {
         unsafe {
             let mut device = Device { device: 0 };
-            driver_sys::cuCtxGetDevice(&mut device.device as *mut driver_sys::CUdevice)
-                .to_result()?;
+            driver::cuCtxGetDevice(&mut device.device as *mut driver::CUdevice).to_result()?;
             Ok(device)
         }
     }
@@ -582,7 +581,7 @@ impl CurrentContext {
     pub fn get_flags() -> CudaResult<ContextFlags> {
         unsafe {
             let mut flags = 0u32;
-            driver_sys::cuCtxGetFlags(&mut flags as *mut u32).to_result()?;
+            driver::cuCtxGetFlags(&mut flags as *mut u32).to_result()?;
             Ok(ContextFlags::from_bits_truncate(flags))
         }
     }
@@ -607,9 +606,9 @@ impl CurrentContext {
     pub fn get_resource_limit(resource: ResourceLimit) -> CudaResult<usize> {
         unsafe {
             let mut limit: usize = 0;
-            driver_sys::cuCtxGetLimit(
+            driver::cuCtxGetLimit(
                 &mut limit as *mut usize,
-                transmute::<ResourceLimit, driver_sys::CUlimit_enum>(resource),
+                transmute::<ResourceLimit, driver::CUlimit_enum>(resource),
             )
             .to_result()?;
             Ok(limit)
@@ -636,8 +635,8 @@ impl CurrentContext {
     pub fn get_shared_memory_config() -> CudaResult<SharedMemoryConfig> {
         unsafe {
             let mut cfg = SharedMemoryConfig::DefaultBankSize;
-            driver_sys::cuCtxGetSharedMemConfig(
-                &mut cfg as *mut SharedMemoryConfig as *mut driver_sys::CUsharedconfig,
+            driver::cuCtxGetSharedMemConfig(
+                &mut cfg as *mut SharedMemoryConfig as *mut driver::CUsharedconfig,
             )
             .to_result()?;
             Ok(cfg)
@@ -671,7 +670,7 @@ impl CurrentContext {
                 least: 0,
                 greatest: 0,
             };
-            driver_sys::cuCtxGetStreamPriorityRange(
+            driver::cuCtxGetStreamPriorityRange(
                 &mut range.least as *mut i32,
                 &mut range.greatest as *mut i32,
             )
@@ -707,10 +706,8 @@ impl CurrentContext {
     /// ```
     pub fn set_cache_config(cfg: CacheConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetCacheConfig(
-                transmute::<CacheConfig, driver_sys::CUfunc_cache_enum>(cfg),
-            )
-            .to_result()
+            driver::cuCtxSetCacheConfig(transmute::<CacheConfig, driver::CUfunc_cache_enum>(cfg))
+                .to_result()
         }
     }
 
@@ -758,8 +755,8 @@ impl CurrentContext {
     /// ```
     pub fn set_resource_limit(resource: ResourceLimit, limit: usize) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetLimit(
-                transmute::<ResourceLimit, driver_sys::CUlimit_enum>(resource),
+            driver::cuCtxSetLimit(
+                transmute::<ResourceLimit, driver::CUlimit_enum>(resource),
                 limit,
             )
             .to_result()?;
@@ -789,9 +786,9 @@ impl CurrentContext {
     /// ```
     pub fn set_shared_memory_config(cfg: SharedMemoryConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetSharedMemConfig(transmute::<
+            driver::cuCtxSetSharedMemConfig(transmute::<
                 SharedMemoryConfig,
-                driver_sys::CUsharedconfig_enum,
+                driver::CUsharedconfig_enum,
             >(cfg))
             .to_result()
         }
@@ -817,7 +814,7 @@ impl CurrentContext {
     pub fn get_current() -> CudaResult<UnownedContext> {
         unsafe {
             let mut ctx: CUcontext = ptr::null_mut();
-            driver_sys::cuCtxGetCurrent(&mut ctx as *mut CUcontext).to_result()?;
+            driver::cuCtxGetCurrent(&mut ctx as *mut CUcontext).to_result()?;
             Ok(UnownedContext { inner: ctx })
         }
     }
@@ -845,7 +842,7 @@ impl CurrentContext {
     /// ```
     pub fn set_current<C: ContextHandle>(c: &C) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetCurrent(c.get_inner()).to_result()?;
+            driver::cuCtxSetCurrent(c.get_inner()).to_result()?;
             Ok(())
         }
     }
@@ -853,7 +850,7 @@ impl CurrentContext {
     /// Block to wait for a context's tasks to complete.
     pub fn synchronize() -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSynchronize().to_result()?;
+            driver::cuCtxSynchronize().to_result()?;
             Ok(())
         }
     }

--- a/crates/cust/src/context/mod.rs
+++ b/crates/cust/src/context/mod.rs
@@ -38,7 +38,7 @@ use std::{
     ptr,
 };
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 /// Legacy context handling.
 pub mod legacy;
@@ -52,11 +52,11 @@ use crate::{
 };
 
 pub trait ContextHandle: Sealed {
-    fn get_inner(&self) -> driver_sys::CUcontext;
+    fn get_inner(&self) -> driver::CUcontext;
 }
 impl Sealed for Context {}
 impl ContextHandle for Context {
-    fn get_inner(&self) -> driver_sys::CUcontext {
+    fn get_inner(&self) -> driver::CUcontext {
         self.inner
     }
 }
@@ -165,8 +165,8 @@ bitflags::bitflags! {
 
 #[derive(Debug)]
 pub struct Context {
-    inner: driver_sys::CUcontext,
-    device: driver_sys::CUdevice,
+    inner: driver::CUcontext,
+    device: driver::CUdevice,
 }
 
 unsafe impl Send for Context {}
@@ -194,10 +194,9 @@ impl Context {
     pub fn new(device: Device) -> CudaResult<Self> {
         let mut inner = MaybeUninit::uninit();
         unsafe {
-            driver_sys::cuDevicePrimaryCtxRetain(inner.as_mut_ptr(), device.as_raw())
-                .to_result()?;
+            driver::cuDevicePrimaryCtxRetain(inner.as_mut_ptr(), device.as_raw()).to_result()?;
             let inner = inner.assume_init();
-            driver_sys::cuCtxSetCurrent(inner).to_result()?;
+            driver::cuCtxSetCurrent(inner).to_result()?;
             Ok(Self {
                 inner,
                 device: device.as_raw(),
@@ -215,17 +214,17 @@ impl Context {
     /// Nothing else should be using the primary context for this device, otherwise,
     /// spurious errors or segfaults will occur.
     pub unsafe fn reset(device: &Device) -> CudaResult<()> {
-        driver_sys::cuDevicePrimaryCtxReset(device.as_raw()).to_result()
+        driver::cuDevicePrimaryCtxReset(device.as_raw()).to_result()
     }
 
     /// Sets the flags for the device context, these flags will apply to any user of the primary
     /// context associated with this device.
     pub fn set_flags(&self, flags: ContextFlags) -> CudaResult<()> {
-        unsafe { driver_sys::cuDevicePrimaryCtxSetFlags(self.device, flags.bits()).to_result() }
+        unsafe { driver::cuDevicePrimaryCtxSetFlags(self.device, flags.bits()).to_result() }
     }
 
     /// Returns the raw handle to this context.
-    pub fn as_raw(&self) -> driver_sys::CUcontext {
+    pub fn as_raw(&self) -> driver::CUcontext {
         self.inner
     }
 
@@ -251,7 +250,7 @@ impl Context {
     pub fn get_api_version(&self) -> CudaResult<CudaApiVersion> {
         unsafe {
             let mut api_version = 0u32;
-            driver_sys::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
+            driver::cuCtxGetApiVersion(self.inner, &mut api_version as *mut u32).to_result()?;
             Ok(CudaApiVersion {
                 version: api_version as i32,
             })
@@ -291,7 +290,7 @@ impl Context {
 
         unsafe {
             let inner = mem::replace(&mut ctx.inner, ptr::null_mut());
-            match driver_sys::cuDevicePrimaryCtxRelease(ctx.device).to_result() {
+            match driver::cuDevicePrimaryCtxRelease(ctx.device).to_result() {
                 Ok(()) => {
                     mem::forget(ctx);
                     Ok(())
@@ -316,7 +315,7 @@ impl Drop for Context {
 
         unsafe {
             self.inner = ptr::null_mut();
-            let _ = driver_sys::cuDevicePrimaryCtxRelease(self.device);
+            let _ = driver::cuDevicePrimaryCtxRelease(self.device);
         }
     }
 }
@@ -350,8 +349,8 @@ impl CurrentContext {
     pub fn get_cache_config() -> CudaResult<CacheConfig> {
         unsafe {
             let mut config = CacheConfig::PreferNone;
-            driver_sys::cuCtxGetCacheConfig(
-                &mut config as *mut CacheConfig as *mut driver_sys::CUfunc_cache,
+            driver::cuCtxGetCacheConfig(
+                &mut config as *mut CacheConfig as *mut driver::CUfunc_cache,
             )
             .to_result()?;
             Ok(config)
@@ -378,8 +377,7 @@ impl CurrentContext {
     pub fn get_device() -> CudaResult<Device> {
         unsafe {
             let mut device = Device { device: 0 };
-            driver_sys::cuCtxGetDevice(&mut device.device as *mut driver_sys::CUdevice)
-                .to_result()?;
+            driver::cuCtxGetDevice(&mut device.device as *mut driver::CUdevice).to_result()?;
             Ok(device)
         }
     }
@@ -404,7 +402,7 @@ impl CurrentContext {
     pub fn get_flags() -> CudaResult<ContextFlags> {
         unsafe {
             let mut flags = 0u32;
-            driver_sys::cuCtxGetFlags(&mut flags as *mut u32).to_result()?;
+            driver::cuCtxGetFlags(&mut flags as *mut u32).to_result()?;
             Ok(ContextFlags::from_bits_truncate(flags))
         }
     }
@@ -429,9 +427,9 @@ impl CurrentContext {
     pub fn get_resource_limit(resource: ResourceLimit) -> CudaResult<usize> {
         unsafe {
             let mut limit: usize = 0;
-            driver_sys::cuCtxGetLimit(
+            driver::cuCtxGetLimit(
                 &mut limit as *mut usize,
-                transmute::<ResourceLimit, driver_sys::CUlimit_enum>(resource),
+                transmute::<ResourceLimit, driver::CUlimit_enum>(resource),
             )
             .to_result()?;
             Ok(limit)
@@ -458,8 +456,8 @@ impl CurrentContext {
     pub fn get_shared_memory_config() -> CudaResult<SharedMemoryConfig> {
         unsafe {
             let mut cfg = SharedMemoryConfig::DefaultBankSize;
-            driver_sys::cuCtxGetSharedMemConfig(
-                &mut cfg as *mut SharedMemoryConfig as *mut driver_sys::CUsharedconfig,
+            driver::cuCtxGetSharedMemConfig(
+                &mut cfg as *mut SharedMemoryConfig as *mut driver::CUsharedconfig,
             )
             .to_result()?;
             Ok(cfg)
@@ -493,7 +491,7 @@ impl CurrentContext {
                 least: 0,
                 greatest: 0,
             };
-            driver_sys::cuCtxGetStreamPriorityRange(
+            driver::cuCtxGetStreamPriorityRange(
                 &mut range.least as *mut i32,
                 &mut range.greatest as *mut i32,
             )
@@ -529,10 +527,8 @@ impl CurrentContext {
     /// ```
     pub fn set_cache_config(cfg: CacheConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetCacheConfig(
-                transmute::<CacheConfig, driver_sys::CUfunc_cache_enum>(cfg),
-            )
-            .to_result()
+            driver::cuCtxSetCacheConfig(transmute::<CacheConfig, driver::CUfunc_cache_enum>(cfg))
+                .to_result()
         }
     }
 
@@ -581,8 +577,8 @@ impl CurrentContext {
     /// ```
     pub fn set_resource_limit(resource: ResourceLimit, limit: usize) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetLimit(
-                transmute::<ResourceLimit, driver_sys::CUlimit_enum>(resource),
+            driver::cuCtxSetLimit(
+                transmute::<ResourceLimit, driver::CUlimit_enum>(resource),
                 limit,
             )
             .to_result()?;
@@ -612,9 +608,9 @@ impl CurrentContext {
     /// ```
     pub fn set_shared_memory_config(cfg: SharedMemoryConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetSharedMemConfig(transmute::<
+            driver::cuCtxSetSharedMemConfig(transmute::<
                 SharedMemoryConfig,
-                driver_sys::CUsharedconfig_enum,
+                driver::CUsharedconfig_enum,
             >(cfg))
             .to_result()
         }
@@ -639,7 +635,7 @@ impl CurrentContext {
     /// ```
     pub fn set_current<C: ContextHandle>(c: &C) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSetCurrent(c.get_inner()).to_result()?;
+            driver::cuCtxSetCurrent(c.get_inner()).to_result()?;
             Ok(())
         }
     }
@@ -647,7 +643,7 @@ impl CurrentContext {
     /// Block to wait for a context's tasks to complete.
     pub fn synchronize() -> CudaResult<()> {
         unsafe {
-            driver_sys::cuCtxSynchronize().to_result()?;
+            driver::cuCtxSynchronize().to_result()?;
             Ok(())
         }
     }

--- a/crates/cust/src/device.rs
+++ b/crates/cust/src/device.rs
@@ -3,7 +3,7 @@
 use std::ffi::CStr;
 use std::ops::Range;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, ToResult};
 
@@ -200,7 +200,7 @@ pub enum DeviceAttribute {
 /// Opaque handle to a CUDA device.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Device {
-    pub(crate) device: driver_sys::CUdevice,
+    pub(crate) device: driver::CUdevice,
 }
 impl Device {
     /// Get the number of CUDA-capable devices.
@@ -223,7 +223,7 @@ impl Device {
     pub fn num_devices() -> CudaResult<u32> {
         unsafe {
             let mut num_devices = 0i32;
-            driver_sys::cuDeviceGetCount(&mut num_devices as *mut i32).to_result()?;
+            driver::cuDeviceGetCount(&mut num_devices as *mut i32).to_result()?;
             Ok(num_devices as u32)
         }
     }
@@ -247,11 +247,8 @@ impl Device {
     pub fn get_device(ordinal: u32) -> CudaResult<Device> {
         unsafe {
             let mut device = Device { device: 0 };
-            driver_sys::cuDeviceGet(
-                &mut device.device as *mut driver_sys::CUdevice,
-                ordinal as i32,
-            )
-            .to_result()?;
+            driver::cuDeviceGet(&mut device.device as *mut driver::CUdevice, ordinal as i32)
+                .to_result()?;
             Ok(device)
         }
     }
@@ -295,7 +292,7 @@ impl Device {
     pub fn total_memory(self) -> CudaResult<usize> {
         unsafe {
             let mut memory = 0;
-            driver_sys::cuDeviceTotalMem(&mut memory as *mut usize, self.device).to_result()?;
+            driver::cuDeviceTotalMem(&mut memory as *mut usize, self.device).to_result()?;
             Ok(memory)
         }
     }
@@ -317,7 +314,7 @@ impl Device {
     pub fn name(self) -> CudaResult<String> {
         unsafe {
             let mut name = [0u8; 128]; // Hopefully this is big enough...
-            driver_sys::cuDeviceGetName(
+            driver::cuDeviceGetName(
                 &mut name[0] as *mut u8 as *mut ::std::os::raw::c_char,
                 128,
                 self.device,
@@ -348,9 +345,9 @@ impl Device {
     /// # }
     /// ```
     pub fn uuid(self) -> CudaResult<[u8; 16]> {
-        let mut cu_uuid = driver_sys::CUuuid { bytes: [0; 16] };
+        let mut cu_uuid = driver::CUuuid { bytes: [0; 16] };
         unsafe {
-            driver_sys::cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
+            driver::cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
         }
         let uuid: [u8; 16] = cu_uuid.bytes.map(|byte| byte as u8);
         Ok(uuid)
@@ -374,10 +371,10 @@ impl Device {
     pub fn get_attribute(self, attr: DeviceAttribute) -> CudaResult<i32> {
         unsafe {
             let mut val = 0i32;
-            driver_sys::cuDeviceGetAttribute(
+            driver::cuDeviceGetAttribute(
                 &mut val as *mut i32,
                 // This should be safe, as the repr and values of DeviceAttribute should match.
-                ::std::mem::transmute::<DeviceAttribute, driver_sys::CUdevice_attribute_enum>(attr),
+                ::std::mem::transmute::<DeviceAttribute, driver::CUdevice_attribute_enum>(attr),
                 self.device,
             )
             .to_result()?;
@@ -387,7 +384,7 @@ impl Device {
 
     /// Returns a raw handle to this device, not handing over ownership, meaning that dropping
     /// this device will try to drop the underlying device.
-    pub fn as_raw(&self) -> driver_sys::CUdevice {
+    pub fn as_raw(&self) -> driver::CUdevice {
         self.device
     }
 }

--- a/crates/cust/src/error.rs
+++ b/crates/cust/src/error.rs
@@ -15,8 +15,8 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::result::Result;
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::cudaError_enum;
+use cust_raw::driver;
+use cust_raw::driver::cudaError_enum;
 
 /// Error enum which represents all the potential errors returned by the CUDA driver API.
 #[repr(u32)]
@@ -98,7 +98,7 @@ impl fmt::Display for CudaError {
                 let value = other as u32;
                 let mut ptr: *const c_char = ptr::null();
                 unsafe {
-                    driver_sys::cuGetErrorString(
+                    driver::cuGetErrorString(
                         mem::transmute::<u32, cudaError_enum>(value),
                         &mut ptr as *mut *const c_char,
                     )

--- a/crates/cust/src/event.rs
+++ b/crates/cust/src/event.rs
@@ -17,7 +17,7 @@ use std::mem;
 use std::ptr;
 use std::time::Duration;
 
-use cust_raw::driver_sys::{
+use cust_raw::driver::{
     cuEventCreate, cuEventDestroy, cuEventElapsedTime, cuEventQuery, cuEventRecord,
     cuEventSynchronize, CUevent,
 };

--- a/crates/cust/src/external.rs
+++ b/crates/cust/src/external.rs
@@ -1,28 +1,29 @@
 //! External memory and synchronization resources
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, ToResult};
 use crate::memory::{DeviceCopy, DevicePointer};
 
 #[repr(transparent)]
-pub struct ExternalMemory(driver_sys::CUexternalMemory);
+pub struct ExternalMemory(driver::CUexternalMemory);
 
 impl ExternalMemory {
     // Import an external memory referenced by `fd` with `size`
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn import(fd: i32, size: usize) -> CudaResult<ExternalMemory> {
-        let desc = driver_sys::CUDA_EXTERNAL_MEMORY_HANDLE_DESC {
-            type_: driver_sys::CUexternalMemoryHandleType_enum::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD,
-            handle: driver_sys::CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st__bindgen_ty_1 { fd },
+        let desc = driver::CUDA_EXTERNAL_MEMORY_HANDLE_DESC {
+            type_:
+                driver::CUexternalMemoryHandleType_enum::CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD,
+            handle: driver::CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st__bindgen_ty_1 { fd },
             size: size as u64,
             flags: 0,
             reserved: Default::default(),
         };
 
-        let mut memory: driver_sys::CUexternalMemory = std::ptr::null_mut();
+        let mut memory: driver::CUexternalMemory = std::ptr::null_mut();
 
-        driver_sys::cuImportExternalMemory(&mut memory, &desc)
+        driver::cuImportExternalMemory(&mut memory, &desc)
             .to_result()
             .map(|_| ExternalMemory(memory))
     }
@@ -41,7 +42,7 @@ impl ExternalMemory {
         size_in_bytes: usize,
         offset_in_bytes: usize,
     ) -> CudaResult<DevicePointer<T>> {
-        let buffer_desc = driver_sys::CUDA_EXTERNAL_MEMORY_BUFFER_DESC {
+        let buffer_desc = driver::CUDA_EXTERNAL_MEMORY_BUFFER_DESC {
             flags: 0,
             size: size_in_bytes as u64,
             offset: offset_in_bytes as u64,
@@ -50,7 +51,7 @@ impl ExternalMemory {
 
         let mut dptr = 0;
         unsafe {
-            driver_sys::cuExternalMemoryGetMappedBuffer(&mut dptr, self.0, &buffer_desc)
+            driver::cuExternalMemoryGetMappedBuffer(&mut dptr, self.0, &buffer_desc)
                 .to_result()
                 .map(|_| DevicePointer::from_raw(dptr))
         }
@@ -60,9 +61,7 @@ impl ExternalMemory {
 impl Drop for ExternalMemory {
     fn drop(&mut self) {
         unsafe {
-            driver_sys::cuDestroyExternalMemory(self.0)
-                .to_result()
-                .unwrap();
+            driver::cuDestroyExternalMemory(self.0).to_result().unwrap();
         }
     }
 }

--- a/crates/cust/src/function.rs
+++ b/crates/cust/src/function.rs
@@ -3,8 +3,8 @@
 use std::marker::PhantomData;
 use std::mem::{transmute, MaybeUninit};
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::CUfunction;
+use cust_raw::driver;
+use cust_raw::driver::CUfunction;
 
 use crate::context::{CacheConfig, SharedMemoryConfig};
 use crate::error::{CudaResult, ToResult};
@@ -243,12 +243,10 @@ impl Function<'_> {
     pub fn get_attribute(&self, attr: FunctionAttribute) -> CudaResult<i32> {
         unsafe {
             let mut val = 0i32;
-            driver_sys::cuFuncGetAttribute(
+            driver::cuFuncGetAttribute(
                 &mut val as *mut i32,
                 // This should be safe, as the repr and values of FunctionAttribute should match.
-                ::std::mem::transmute::<FunctionAttribute, driver_sys::CUfunction_attribute_enum>(
-                    attr,
-                ),
+                ::std::mem::transmute::<FunctionAttribute, driver::CUfunction_attribute_enum>(attr),
                 self.inner,
             )
             .to_result()?;
@@ -286,9 +284,9 @@ impl Function<'_> {
     /// ```
     pub fn set_cache_config(&mut self, config: CacheConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuFuncSetCacheConfig(
+            driver::cuFuncSetCacheConfig(
                 self.inner,
-                transmute::<CacheConfig, driver_sys::CUfunc_cache_enum>(config),
+                transmute::<CacheConfig, driver::CUfunc_cache_enum>(config),
             )
             .to_result()
         }
@@ -319,9 +317,9 @@ impl Function<'_> {
     /// ```
     pub fn set_shared_memory_config(&mut self, cfg: SharedMemoryConfig) -> CudaResult<()> {
         unsafe {
-            driver_sys::cuFuncSetSharedMemConfig(
+            driver::cuFuncSetSharedMemConfig(
                 self.inner,
-                transmute::<SharedMemoryConfig, driver_sys::CUsharedconfig_enum>(cfg),
+                transmute::<SharedMemoryConfig, driver::CUsharedconfig_enum>(cfg),
             )
             .to_result()
         }
@@ -346,7 +344,7 @@ impl Function<'_> {
 
         let mut result = MaybeUninit::uninit();
         unsafe {
-            driver_sys::cuOccupancyAvailableDynamicSMemPerBlock(
+            driver::cuOccupancyAvailableDynamicSMemPerBlock(
                 result.as_mut_ptr(),
                 self.to_raw(),
                 num_blocks as i32,
@@ -368,7 +366,7 @@ impl Function<'_> {
 
         let mut num_blocks = MaybeUninit::uninit();
         unsafe {
-            driver_sys::cuOccupancyMaxActiveBlocksPerMultiprocessor(
+            driver::cuOccupancyMaxActiveBlocksPerMultiprocessor(
                 num_blocks.as_mut_ptr(),
                 self.to_raw(),
                 total_block_size as i32,
@@ -405,7 +403,7 @@ impl Function<'_> {
         let total_block_size_limit = block_size_limit.x * block_size_limit.y * block_size_limit.z;
 
         unsafe {
-            driver_sys::cuOccupancyMaxPotentialBlockSize(
+            driver::cuOccupancyMaxPotentialBlockSize(
                 min_grid_size.as_mut_ptr(),
                 block_size.as_mut_ptr(),
                 self.to_raw(),

--- a/crates/cust/src/graph.rs
+++ b/crates/cust/src/graph.rs
@@ -8,7 +8,7 @@ use std::{
     ptr,
 };
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::{
     error::{CudaResult, ToResult},
@@ -57,7 +57,7 @@ pub struct KernelInvocation {
     pub block_dim: BlockSize,
     pub grid_dim: GridSize,
     pub shared_mem_bytes: u32,
-    func: driver_sys::CUfunction,
+    func: driver::CUfunction,
     params: Box<*mut c_void>,
     params_len: Option<usize>,
 }
@@ -68,7 +68,7 @@ impl KernelInvocation {
         block_dim: BlockSize,
         grid_dim: GridSize,
         shared_mem_bytes: u32,
-        func: driver_sys::CUfunction,
+        func: driver::CUfunction,
         params: Box<*mut c_void>,
         params_len: usize,
     ) -> Self {
@@ -82,8 +82,8 @@ impl KernelInvocation {
         }
     }
 
-    pub fn to_raw(self) -> driver_sys::CUDA_KERNEL_NODE_PARAMS {
-        driver_sys::CUDA_KERNEL_NODE_PARAMS {
+    pub fn to_raw(self) -> driver::CUDA_KERNEL_NODE_PARAMS {
+        driver::CUDA_KERNEL_NODE_PARAMS {
             func: self.func,
             gridDimX: self.grid_dim.x,
             gridDimY: self.grid_dim.y,
@@ -106,7 +106,7 @@ impl KernelInvocation {
     /// The function pointer must be a valid CUfunction pointer and
     /// params' "ownership" must be able to be transferred to the invocation
     /// (it will be turned into a Box).
-    pub unsafe fn from_raw(raw: driver_sys::CUDA_KERNEL_NODE_PARAMS) -> Self {
+    pub unsafe fn from_raw(raw: driver::CUDA_KERNEL_NODE_PARAMS) -> Self {
         Self {
             func: raw.func,
             grid_dim: GridSize::xyz(raw.gridDimX, raw.gridDimY, raw.gridDimZ),
@@ -123,7 +123,7 @@ impl KernelInvocation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct GraphNode {
-    raw: driver_sys::CUgraphNode,
+    raw: driver::CUgraphNode,
 }
 
 unsafe impl Send for GraphNode {}
@@ -132,12 +132,12 @@ unsafe impl Sync for GraphNode {}
 impl GraphNode {
     /// Creates a new node from a raw handle. This is safe because node checks
     /// happen on the graph when functions are called.
-    pub fn from_raw(raw: driver_sys::CUgraphNode) -> Self {
+    pub fn from_raw(raw: driver::CUgraphNode) -> Self {
         Self { raw }
     }
 
     /// Converts this node into a raw handle.
-    pub fn to_raw(self) -> driver_sys::CUgraphNode {
+    pub fn to_raw(self) -> driver::CUgraphNode {
         self.raw
     }
 }
@@ -179,8 +179,8 @@ pub enum GraphNodeType {
 
 impl GraphNodeType {
     /// Converts a raw type to a [`GraphNodeType`].
-    pub fn from_raw(raw: driver_sys::CUgraphNodeType) -> Self {
-        use driver_sys::CUgraphNodeType::*;
+    pub fn from_raw(raw: driver::CUgraphNodeType) -> Self {
+        use driver::CUgraphNodeType::*;
         match raw {
             CU_GRAPH_NODE_TYPE_KERNEL => GraphNodeType::KernelInvocation,
             CU_GRAPH_NODE_TYPE_MEMCPY => GraphNodeType::Memcpy,
@@ -201,8 +201,8 @@ impl GraphNodeType {
     }
 
     /// Converts this type to its raw counterpart.
-    pub fn to_raw(self) -> driver_sys::CUgraphNodeType {
-        use driver_sys::CUgraphNodeType::*;
+    pub fn to_raw(self) -> driver::CUgraphNodeType {
+        use driver::CUgraphNodeType::*;
         match self {
             Self::KernelInvocation => CU_GRAPH_NODE_TYPE_KERNEL,
             Self::Memcpy => CU_GRAPH_NODE_TYPE_MEMCPY,
@@ -250,7 +250,7 @@ impl GraphNodeType {
 /// send graphs between threads.
 #[derive(Debug)]
 pub struct Graph {
-    raw: driver_sys::CUgraph,
+    raw: driver::CUgraph,
     // a cache of nodes, this cache is None when the node cache is out of date,
     // it will get refreshed when get_nodes is called.
     node_cache: Option<Vec<GraphNode>>,
@@ -303,7 +303,7 @@ impl Graph {
     pub fn num_nodes(&mut self) -> CudaResult<usize> {
         unsafe {
             let mut len = MaybeUninit::uninit();
-            driver_sys::cuGraphGetNodes(self.raw, ptr::null_mut(), len.as_mut_ptr()).to_result()?;
+            driver::cuGraphGetNodes(self.raw, ptr::null_mut(), len.as_mut_ptr()).to_result()?;
             Ok(len.assume_init())
         }
     }
@@ -314,9 +314,9 @@ impl Graph {
             unsafe {
                 let mut len = self.num_nodes()?;
                 let mut vec = Vec::with_capacity(len);
-                driver_sys::cuGraphGetNodes(
+                driver::cuGraphGetNodes(
                     self.raw,
-                    vec.as_mut_ptr() as *mut driver_sys::CUgraphNode,
+                    vec.as_mut_ptr() as *mut driver::CUgraphNode,
                     &mut len as *mut usize,
                 )
                 .to_result()?;
@@ -332,7 +332,7 @@ impl Graph {
         let mut raw = MaybeUninit::uninit();
 
         unsafe {
-            driver_sys::cuGraphCreate(raw.as_mut_ptr(), flags.bits()).to_result()?;
+            driver::cuGraphCreate(raw.as_mut_ptr(), flags.bits()).to_result()?;
 
             Ok(Self {
                 raw: raw.assume_init(),
@@ -370,10 +370,10 @@ impl Graph {
         }
 
         unsafe {
-            driver_sys::cuGraphDebugDotPrint(
+            driver::cuGraphDebugDotPrint(
                 self.raw,
                 c"./out.dot".as_ptr(),
-                driver_sys::CUgraphDebugDot_flags::CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE as u32,
+                driver::CUgraphDebugDot_flags::CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE as u32,
             )
             .to_result()
         }
@@ -395,7 +395,7 @@ impl Graph {
             let deps_ptr = deps.as_ptr().cast();
             let mut node = MaybeUninit::<GraphNode>::uninit();
             let params = invocation.to_raw();
-            driver_sys::cuGraphAddKernelNode(
+            driver::cuGraphAddKernelNode(
                 node.as_mut_ptr().cast(),
                 self.raw,
                 deps_ptr,
@@ -411,7 +411,7 @@ impl Graph {
     pub fn num_edges(&mut self) -> CudaResult<usize> {
         unsafe {
             let mut size = MaybeUninit::uninit();
-            driver_sys::cuGraphGetEdges(
+            driver::cuGraphGetEdges(
                 self.raw,
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -435,7 +435,7 @@ impl Graph {
             let mut from = vec![ptr::null_mut(); num_edges].into_boxed_slice();
             let mut to = vec![ptr::null_mut(); num_edges].into_boxed_slice();
 
-            driver_sys::cuGraphGetEdges(
+            driver::cuGraphGetEdges(
                 self.raw,
                 from.as_mut_ptr(),
                 to.as_mut_ptr(),
@@ -456,7 +456,7 @@ impl Graph {
         self.check_deps_are_valid("node_type", &[node])?;
         unsafe {
             let mut ty = MaybeUninit::uninit();
-            driver_sys::cuGraphNodeGetType(node.to_raw(), ty.as_mut_ptr()).to_result()?;
+            driver::cuGraphNodeGetType(node.to_raw(), ty.as_mut_ptr()).to_result()?;
             let raw = ty.assume_init();
             Ok(GraphNodeType::from_raw(raw))
         }
@@ -476,7 +476,7 @@ impl Graph {
         );
         unsafe {
             let mut params = MaybeUninit::uninit();
-            driver_sys::cuGraphKernelNodeGetParams(node.to_raw(), params.as_mut_ptr());
+            driver::cuGraphKernelNodeGetParams(node.to_raw(), params.as_mut_ptr());
             Ok(KernelInvocation::from_raw(params.assume_init()))
         }
     }
@@ -489,7 +489,7 @@ impl Graph {
     /// - This handle is exclusive, nothing else can use it in any way, including trying to drop it.
     /// - It must be a valid handle. This invariant must be upheld, the library is allowed to rely on
     /// the fact that the handle is valid in terms of safety, therefore failure to uphold this invariant is UB.
-    pub unsafe fn from_raw(raw: driver_sys::CUgraph) -> Self {
+    pub unsafe fn from_raw(raw: driver::CUgraph) -> Self {
         Self {
             raw,
             node_cache: None,
@@ -498,7 +498,7 @@ impl Graph {
 
     /// Consumes this [`Graph`], turning it into a raw handle. The handle will not be dropped,
     /// it is up to the caller to ensure the graph is destroyed.
-    pub fn into_raw(self) -> driver_sys::CUgraph {
+    pub fn into_raw(self) -> driver::CUgraph {
         let me = ManuallyDrop::new(self);
         me.raw
     }
@@ -507,7 +507,7 @@ impl Graph {
 impl Drop for Graph {
     fn drop(&mut self) {
         unsafe {
-            driver_sys::cuGraphDestroy(self.raw);
+            driver::cuGraphDestroy(self.raw);
         }
     }
 }

--- a/crates/cust/src/lib.rs
+++ b/crates/cust/src/lib.rs
@@ -80,7 +80,7 @@ use crate::context::{Context, ContextFlags};
 use crate::device::Device;
 use crate::error::{CudaResult, ToResult};
 use bitflags::bitflags;
-use cust_raw::driver_sys::{cuDriverGetVersion, cuInit};
+use cust_raw::driver::{cuDriverGetVersion, cuInit};
 
 bitflags! {
     /// Bit flags for initializing the CUDA driver. Currently, no flags are defined,

--- a/crates/cust/src/link.rs
+++ b/crates/cust/src/link.rs
@@ -3,7 +3,7 @@
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, ToResult};
 
@@ -12,7 +12,7 @@ static UNNAMED: &str = "\0";
 /// A linker used to link together PTX files into a single module.
 #[derive(Debug)]
 pub struct Linker {
-    raw: driver_sys::CUlinkState,
+    raw: driver::CUlinkState,
 }
 
 unsafe impl Send for Linker {}
@@ -27,7 +27,7 @@ impl Linker {
 
         unsafe {
             let mut raw = MaybeUninit::uninit();
-            driver_sys::cuLinkCreate(0, null_mut(), null_mut(), raw.as_mut_ptr()).to_result()?;
+            driver::cuLinkCreate(0, null_mut(), null_mut(), raw.as_mut_ptr()).to_result()?;
             Ok(Self {
                 raw: raw.assume_init(),
             })
@@ -48,9 +48,9 @@ impl Linker {
         let ptx = ptx.as_ref();
 
         unsafe {
-            driver_sys::cuLinkAddData(
+            driver::cuLinkAddData(
                 self.raw,
-                driver_sys::CUjitInputType::CU_JIT_INPUT_PTX,
+                driver::CUjitInputType::CU_JIT_INPUT_PTX,
                 // cuda_sys wants *mut but from the API docs we know we retain ownership so
                 // this cast is sound.
                 ptx.as_ptr() as *mut _,
@@ -73,9 +73,9 @@ impl Linker {
         let cubin = cubin.as_ref();
 
         unsafe {
-            driver_sys::cuLinkAddData(
+            driver::cuLinkAddData(
                 self.raw,
-                driver_sys::CUjitInputType::CU_JIT_INPUT_CUBIN,
+                driver::CUjitInputType::CU_JIT_INPUT_CUBIN,
                 // cuda_sys wants *mut but from the API docs we know we retain ownership so
                 // this cast is sound.
                 cubin.as_ptr() as *mut _,
@@ -98,9 +98,9 @@ impl Linker {
         let fatbin = fatbin.as_ref();
 
         unsafe {
-            driver_sys::cuLinkAddData(
+            driver::cuLinkAddData(
                 self.raw,
-                driver_sys::CUjitInputType::CU_JIT_INPUT_FATBINARY,
+                driver::CUjitInputType::CU_JIT_INPUT_FATBINARY,
                 // cuda_sys wants *mut but from the API docs we know we retain ownership so
                 // this cast is sound.
                 fatbin.as_ptr() as *mut _,
@@ -121,8 +121,7 @@ impl Linker {
         let mut size = MaybeUninit::uninit();
 
         unsafe {
-            driver_sys::cuLinkComplete(self.raw, cubin.as_mut_ptr(), size.as_mut_ptr())
-                .to_result()?;
+            driver::cuLinkComplete(self.raw, cubin.as_mut_ptr(), size.as_mut_ptr()).to_result()?;
             // docs say that CULinkState owns the data, so clone it out before we destroy ourselves.
             let cubin = cubin.assume_init() as *const u8;
             let size = size.assume_init();
@@ -138,7 +137,7 @@ impl Linker {
 impl Drop for Linker {
     fn drop(&mut self) {
         unsafe {
-            let _ = driver_sys::cuLinkDestroy(self.raw);
+            let _ = driver::cuLinkDestroy(self.raw);
         };
     }
 }

--- a/crates/cust/src/memory/array.rs
+++ b/crates/cust/src/memory/array.rs
@@ -13,12 +13,12 @@ use std::panic;
 use std::ptr::null;
 use std::ptr::null_mut;
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::cuMemcpy2D;
-use cust_raw::driver_sys::cuMemcpyAtoH;
-use cust_raw::driver_sys::cuMemcpyHtoA;
-use cust_raw::driver_sys::CUDA_MEMCPY2D;
-use cust_raw::driver_sys::{CUarray, CUarray_format, CUarray_format_enum};
+use cust_raw::driver;
+use cust_raw::driver::cuMemcpy2D;
+use cust_raw::driver::cuMemcpyAtoH;
+use cust_raw::driver::cuMemcpyHtoA;
+use cust_raw::driver::CUDA_MEMCPY2D;
+use cust_raw::driver::{CUarray, CUarray_format, CUarray_format_enum};
 
 use crate::context::CurrentContext;
 use crate::device::DeviceAttribute;
@@ -164,19 +164,19 @@ bitflags::bitflags! {
     pub struct ArrayObjectFlags: c_uint {
         /// Enables creation of layered CUDA arrays. When this flag is set, depth specifies the
         /// number of layers, not the depth of a 3D array.
-        const LAYERED = driver_sys::CUDA_ARRAY3D_LAYERED;
+        const LAYERED = driver::CUDA_ARRAY3D_LAYERED;
 
         /// Enables surface references to be bound to the CUDA array.
-        const SURFACE_LDST = driver_sys::CUDA_ARRAY3D_SURFACE_LDST;
+        const SURFACE_LDST = driver::CUDA_ARRAY3D_SURFACE_LDST;
 
         /// Enables creation of cubemaps. If this flag is set, Width must be equal to Height, and
         /// Depth must be six. If the `LAYERED` flag is also set, then Depth must be a multiple of
         /// six.
-        const CUBEMAP = driver_sys::CUDA_ARRAY3D_CUBEMAP;
+        const CUBEMAP = driver::CUDA_ARRAY3D_CUBEMAP;
 
         /// Indicates that the CUDA array will be used for texture gather. Texture gather can only
         /// be performed on 2D CUDA arrays.
-        const TEXTURE_GATHER = driver_sys::CUDA_ARRAY3D_TEXTURE_GATHER;
+        const TEXTURE_GATHER = driver::CUDA_ARRAY3D_TEXTURE_GATHER;
     }
 }
 
@@ -190,12 +190,12 @@ impl ArrayObjectFlags {
 /// Describes a CUDA Array
 #[derive(Clone, Copy, Debug)]
 pub struct ArrayDescriptor {
-    desc: driver_sys::CUDA_ARRAY3D_DESCRIPTOR,
+    desc: driver::CUDA_ARRAY3D_DESCRIPTOR,
 }
 
 impl ArrayDescriptor {
     /// Constructs an ArrayDescriptor from a CUDA Driver API Array Descriptor.
-    pub fn from_raw(desc: driver_sys::CUDA_ARRAY3D_DESCRIPTOR) -> Self {
+    pub fn from_raw(desc: driver::CUDA_ARRAY3D_DESCRIPTOR) -> Self {
         Self { desc }
     }
 
@@ -207,7 +207,7 @@ impl ArrayDescriptor {
         flags: ArrayObjectFlags,
     ) -> Self {
         Self {
-            desc: driver_sys::CUDA_ARRAY3D_DESCRIPTOR {
+            desc: driver::CUDA_ARRAY3D_DESCRIPTOR {
                 Width: dims[0],
                 Height: dims[1],
                 Depth: dims[2],
@@ -221,7 +221,7 @@ impl ArrayDescriptor {
     /// Creates a new ArrayDescriptor from a set of dimensions and format.
     pub fn from_dims_format(dims: [usize; 3], format: ArrayFormat) -> Self {
         Self {
-            desc: driver_sys::CUDA_ARRAY3D_DESCRIPTOR {
+            desc: driver::CUDA_ARRAY3D_DESCRIPTOR {
                 Width: dims[0],
                 Height: dims[1],
                 Depth: dims[2],
@@ -479,8 +479,7 @@ impl ArrayObject {
         }
 
         let mut handle = MaybeUninit::uninit();
-        unsafe { driver_sys::cuArray3DCreate(handle.as_mut_ptr(), &descriptor.desc) }
-            .to_result()?;
+        unsafe { driver::cuArray3DCreate(handle.as_mut_ptr(), &descriptor.desc) }.to_result()?;
         Ok(Self {
             handle: unsafe { handle.assume_init() },
         })
@@ -731,7 +730,7 @@ impl ArrayObject {
     pub fn descriptor(&self) -> CudaResult<ArrayDescriptor> {
         // Use "zeroed" incase CUDA_ARRAY3D_DESCRIPTOR has uninitialized padding
         let mut raw_descriptor = MaybeUninit::zeroed();
-        unsafe { driver_sys::cuArray3DGetDescriptor(raw_descriptor.as_mut_ptr(), self.handle) }
+        unsafe { driver::cuArray3DGetDescriptor(raw_descriptor.as_mut_ptr(), self.handle) }
             .to_result()?;
 
         Ok(ArrayDescriptor::from_raw(unsafe {
@@ -742,7 +741,7 @@ impl ArrayObject {
     /// Try to destroy an `ArrayObject`. Can fail - if it does, returns the CUDA error and the
     /// un-destroyed array object
     pub fn drop(array: ArrayObject) -> DropResult<ArrayObject> {
-        match unsafe { driver_sys::cuArrayDestroy(array.handle) }.to_result() {
+        match unsafe { driver::cuArrayDestroy(array.handle) }.to_result() {
             Ok(()) => Ok(()),
             Err(e) => Err((e, array)),
         }
@@ -774,14 +773,14 @@ impl ArrayObject {
                     dstArray: self.handle,
                     dstDevice: 0,
                     dstHost: null_mut(),
-                    dstMemoryType: driver_sys::CUmemorytype_enum::CU_MEMORYTYPE_ARRAY,
+                    dstMemoryType: driver::CUmemorytype_enum::CU_MEMORYTYPE_ARRAY,
                     dstPitch: 0,
                     dstXInBytes: 0,
                     dstY: 0,
                     srcArray: null_mut(),
                     srcDevice: 0,
                     srcHost: val.as_ptr() as *const c_void,
-                    srcMemoryType: driver_sys::CUmemorytype_enum::CU_MEMORYTYPE_HOST,
+                    srcMemoryType: driver::CUmemorytype_enum::CU_MEMORYTYPE_HOST,
                     srcPitch: 0,
                     srcXInBytes: 0,
                     srcY: 0,
@@ -818,14 +817,14 @@ impl ArrayObject {
                     dstArray: null_mut(),
                     dstDevice: 0,
                     dstHost: val.as_mut_ptr() as *mut c_void,
-                    dstMemoryType: driver_sys::CUmemorytype_enum::CU_MEMORYTYPE_HOST,
+                    dstMemoryType: driver::CUmemorytype_enum::CU_MEMORYTYPE_HOST,
                     dstPitch: 0,
                     dstXInBytes: 0,
                     dstY: 0,
                     srcArray: self.handle,
                     srcDevice: 0,
                     srcHost: null(),
-                    srcMemoryType: driver_sys::CUmemorytype_enum::CU_MEMORYTYPE_ARRAY,
+                    srcMemoryType: driver::CUmemorytype_enum::CU_MEMORYTYPE_ARRAY,
                     srcPitch: 0,
                     srcXInBytes: 0,
                     srcY: 0,
@@ -868,7 +867,7 @@ impl std::fmt::Debug for ArrayObject {
 impl Drop for ArrayObject {
     fn drop(&mut self) {
         unsafe {
-            let _ = driver_sys::cuArrayDestroy(self.handle);
+            let _ = driver::cuArrayDestroy(self.handle);
         };
     }
 }

--- a/crates/cust/src/memory/device/device_box.rs
+++ b/crates/cust/src/memory/device/device_box.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Pointer};
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::os::raw::c_void;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, DropResult, ToResult};
 use crate::memory::device::AsyncCopyDestination;
@@ -164,7 +164,7 @@ impl<T: DeviceCopy + bytemuck::Zeroable> DeviceBox<T> {
         unsafe {
             let new_box = DeviceBox::uninitialized()?;
             if mem::size_of::<T>() != 0 {
-                driver_sys::cuMemsetD8(new_box.as_device_ptr().as_raw(), 0, mem::size_of::<T>())
+                driver::cuMemsetD8(new_box.as_device_ptr().as_raw(), 0, mem::size_of::<T>())
                     .to_result()?;
             }
             Ok(new_box)
@@ -206,7 +206,7 @@ impl<T: DeviceCopy + bytemuck::Zeroable> DeviceBox<T> {
     pub unsafe fn zeroed_async(stream: &Stream) -> CudaResult<Self> {
         let new_box = DeviceBox::uninitialized_async(stream)?;
         if mem::size_of::<T>() != 0 {
-            driver_sys::cuMemsetD8Async(
+            driver::cuMemsetD8Async(
                 new_box.as_device_ptr().as_raw(),
                 0,
                 mem::size_of::<T>(),
@@ -293,7 +293,7 @@ impl<T: DeviceCopy> DeviceBox<T> {
     /// let ptr = DeviceBox::into_device(x).as_raw_mut();
     /// let x = unsafe { DeviceBox::from_raw(ptr) };
     /// ```
-    pub unsafe fn from_raw(ptr: driver_sys::CUdeviceptr) -> Self {
+    pub unsafe fn from_raw(ptr: driver::CUdeviceptr) -> Self {
         DeviceBox {
             ptr: DevicePointer::from_raw(ptr),
         }
@@ -430,7 +430,7 @@ impl<T: DeviceCopy> CopyDestination<T> for DeviceBox<T> {
         let size = mem::size_of::<T>();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyHtoD(self.ptr.as_raw(), val as *const T as *const c_void, size)
+                driver::cuMemcpyHtoD(self.ptr.as_raw(), val as *const T as *const c_void, size)
                     .to_result()?
             }
         }
@@ -441,7 +441,7 @@ impl<T: DeviceCopy> CopyDestination<T> for DeviceBox<T> {
         let size = mem::size_of::<T>();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyDtoH(val as *const T as *mut c_void, self.ptr.as_raw(), size)
+                driver::cuMemcpyDtoH(val as *const T as *mut c_void, self.ptr.as_raw(), size)
                     .to_result()?
             }
         }
@@ -452,9 +452,7 @@ impl<T: DeviceCopy> CopyDestination<DeviceBox<T>> for DeviceBox<T> {
     fn copy_from(&mut self, val: &DeviceBox<T>) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            unsafe {
-                driver_sys::cuMemcpyDtoD(self.ptr.as_raw(), val.ptr.as_raw(), size).to_result()?
-            }
+            unsafe { driver::cuMemcpyDtoD(self.ptr.as_raw(), val.ptr.as_raw(), size).to_result()? }
         }
         Ok(())
     }
@@ -462,9 +460,7 @@ impl<T: DeviceCopy> CopyDestination<DeviceBox<T>> for DeviceBox<T> {
     fn copy_to(&self, val: &mut DeviceBox<T>) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            unsafe {
-                driver_sys::cuMemcpyDtoD(val.ptr.as_raw(), self.ptr.as_raw(), size).to_result()?
-            }
+            unsafe { driver::cuMemcpyDtoD(val.ptr.as_raw(), self.ptr.as_raw(), size).to_result()? }
         }
         Ok(())
     }
@@ -473,7 +469,7 @@ impl<T: DeviceCopy> AsyncCopyDestination<T> for DeviceBox<T> {
     unsafe fn async_copy_from(&mut self, val: &T, stream: &Stream) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            driver_sys::cuMemcpyHtoDAsync(
+            driver::cuMemcpyHtoDAsync(
                 self.ptr.as_raw(),
                 val as *const _ as *const c_void,
                 size,
@@ -487,7 +483,7 @@ impl<T: DeviceCopy> AsyncCopyDestination<T> for DeviceBox<T> {
     unsafe fn async_copy_to(&self, val: &mut T, stream: &Stream) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            driver_sys::cuMemcpyDtoHAsync(
+            driver::cuMemcpyDtoHAsync(
                 val as *mut _ as *mut c_void,
                 self.ptr.as_raw(),
                 size,
@@ -502,13 +498,8 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceBox<T>> for DeviceBox<T> {
     unsafe fn async_copy_from(&mut self, val: &DeviceBox<T>, stream: &Stream) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            driver_sys::cuMemcpyDtoDAsync(
-                self.ptr.as_raw(),
-                val.ptr.as_raw(),
-                size,
-                stream.as_inner(),
-            )
-            .to_result()?
+            driver::cuMemcpyDtoDAsync(self.ptr.as_raw(), val.ptr.as_raw(), size, stream.as_inner())
+                .to_result()?
         }
         Ok(())
     }
@@ -516,13 +507,8 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceBox<T>> for DeviceBox<T> {
     unsafe fn async_copy_to(&self, val: &mut DeviceBox<T>, stream: &Stream) -> CudaResult<()> {
         let size = mem::size_of::<T>();
         if size != 0 {
-            driver_sys::cuMemcpyDtoDAsync(
-                val.ptr.as_raw(),
-                self.ptr.as_raw(),
-                size,
-                stream.as_inner(),
-            )
-            .to_result()?
+            driver::cuMemcpyDtoDAsync(val.ptr.as_raw(), self.ptr.as_raw(), size, stream.as_inner())
+                .to_result()?
         }
         Ok(())
     }

--- a/crates/cust/src/memory/device/device_buffer.rs
+++ b/crates/cust/src/memory/device/device_buffer.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 pub use bytemuck;
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodCastError, Zeroable};
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, DropResult, ToResult};
 use crate::memory::device::{AsyncCopyDestination, CopyDestination, DeviceSlice};
@@ -232,7 +232,7 @@ impl<T: DeviceCopy + Zeroable> DeviceBuffer<T> {
         unsafe {
             let new_buf = DeviceBuffer::uninitialized(size)?;
             if size_of::<T>() != 0 {
-                driver_sys::cuMemsetD8(new_buf.as_device_ptr().as_raw(), 0, size_of::<T>() * size)
+                driver::cuMemsetD8(new_buf.as_device_ptr().as_raw(), 0, size_of::<T>() * size)
                     .to_result()?;
             }
             Ok(new_buf)
@@ -274,7 +274,7 @@ impl<T: DeviceCopy + Zeroable> DeviceBuffer<T> {
     pub unsafe fn zeroed_async(size: usize, stream: &Stream) -> CudaResult<Self> {
         let new_buf = DeviceBuffer::uninitialized_async(size, stream)?;
         if size_of::<T>() != 0 {
-            driver_sys::cuMemsetD8Async(
+            driver::cuMemsetD8Async(
                 new_buf.as_device_ptr().as_raw(),
                 0,
                 size_of::<T>() * size,

--- a/crates/cust/src/memory/device/device_slice.rs
+++ b/crates/cust/src/memory/device/device_slice.rs
@@ -9,7 +9,7 @@ use std::slice;
 
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, Zeroable};
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, ToResult};
 use crate::memory::device::AsyncCopyDestination;
@@ -249,9 +249,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
 
         // SAFETY: We know T can hold any value because it is `Pod`, and
         // sub-byte alignment isn't a thing so we know the alignment is right.
-        unsafe {
-            driver_sys::cuMemsetD8(self.as_raw_ptr(), value, self.size_in_bytes()).to_result()
-        }
+        unsafe { driver::cuMemsetD8(self.as_raw_ptr(), value, self.size_in_bytes()).to_result() }
     }
 
     /// Sets the memory range of this buffer to contiguous `8-bit` values of `value` asynchronously.
@@ -268,7 +266,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
             return Ok(());
         }
 
-        driver_sys::cuMemsetD8Async(
+        driver::cuMemsetD8Async(
             self.as_raw_ptr(),
             value,
             self.size_in_bytes(),
@@ -300,7 +298,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
             0,
             "Buffer pointer is not aligned to at least 2 bytes!"
         );
-        unsafe { driver_sys::cuMemsetD16(self.as_raw_ptr(), value, data_len / 2).to_result() }
+        unsafe { driver::cuMemsetD16(self.as_raw_ptr(), value, data_len / 2).to_result() }
     }
 
     /// Sets the memory range of this buffer to contiguous `16-bit` values of `value` asynchronously.
@@ -331,7 +329,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
             0,
             "Buffer pointer is not aligned to at least 2 bytes!"
         );
-        driver_sys::cuMemsetD16Async(self.as_raw_ptr(), value, data_len / 2, stream.as_inner())
+        driver::cuMemsetD16Async(self.as_raw_ptr(), value, data_len / 2, stream.as_inner())
             .to_result()
     }
 
@@ -358,7 +356,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
             0,
             "Buffer pointer is not aligned to at least 4 bytes!"
         );
-        unsafe { driver_sys::cuMemsetD32(self.as_raw_ptr(), value, data_len / 4).to_result() }
+        unsafe { driver::cuMemsetD32(self.as_raw_ptr(), value, data_len / 4).to_result() }
     }
 
     /// Sets the memory range of this buffer to contiguous `32-bit` values of `value` asynchronously.
@@ -389,7 +387,7 @@ impl<T: DeviceCopy + Pod> DeviceSlice<T> {
             0,
             "Buffer pointer is not aligned to at least 4 bytes!"
         );
-        driver_sys::cuMemsetD32Async(self.as_raw_ptr(), value, data_len / 4, stream.as_inner())
+        driver::cuMemsetD32Async(self.as_raw_ptr(), value, data_len / 4, stream.as_inner())
             .to_result()
     }
 }
@@ -651,7 +649,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> CopyDestination<I> for 
         let size = self.size_in_bytes();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyHtoD(self.as_raw_ptr(), val.as_ptr() as *const c_void, size)
+                driver::cuMemcpyHtoD(self.as_raw_ptr(), val.as_ptr() as *const c_void, size)
                     .to_result()?
             }
         }
@@ -667,7 +665,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> CopyDestination<I> for 
         let size = self.size_in_bytes();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyDtoH(val.as_mut_ptr() as *mut c_void, self.as_raw_ptr(), size)
+                driver::cuMemcpyDtoH(val.as_mut_ptr() as *mut c_void, self.as_raw_ptr(), size)
                     .to_result()?
             }
         }
@@ -682,9 +680,7 @@ impl<T: DeviceCopy> CopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            unsafe {
-                driver_sys::cuMemcpyDtoD(self.as_raw_ptr(), val.as_raw_ptr(), size).to_result()?
-            }
+            unsafe { driver::cuMemcpyDtoD(self.as_raw_ptr(), val.as_raw_ptr(), size).to_result()? }
         }
         Ok(())
     }
@@ -696,9 +692,7 @@ impl<T: DeviceCopy> CopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            unsafe {
-                driver_sys::cuMemcpyDtoD(val.as_raw_ptr(), self.as_raw_ptr(), size).to_result()?
-            }
+            unsafe { driver::cuMemcpyDtoD(val.as_raw_ptr(), self.as_raw_ptr(), size).to_result()? }
         }
         Ok(())
     }
@@ -723,7 +717,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> AsyncCopyDestination<I>
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            driver_sys::cuMemcpyHtoDAsync(
+            driver::cuMemcpyHtoDAsync(
                 self.as_raw_ptr(),
                 val.as_ptr() as *const c_void,
                 size,
@@ -742,7 +736,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> AsyncCopyDestination<I>
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            driver_sys::cuMemcpyDtoHAsync(
+            driver::cuMemcpyDtoHAsync(
                 val.as_mut_ptr() as *mut c_void,
                 self.as_raw_ptr(),
                 size,
@@ -761,13 +755,8 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            driver_sys::cuMemcpyDtoDAsync(
-                self.as_raw_ptr(),
-                val.as_raw_ptr(),
-                size,
-                stream.as_inner(),
-            )
-            .to_result()?
+            driver::cuMemcpyDtoDAsync(self.as_raw_ptr(), val.as_raw_ptr(), size, stream.as_inner())
+                .to_result()?
         }
         Ok(())
     }
@@ -779,13 +768,8 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = self.size_in_bytes();
         if size != 0 {
-            driver_sys::cuMemcpyDtoDAsync(
-                val.as_raw_ptr(),
-                self.as_raw_ptr(),
-                size,
-                stream.as_inner(),
-            )
-            .to_result()?
+            driver::cuMemcpyDtoDAsync(val.as_raw_ptr(), self.as_raw_ptr(), size, stream.as_inner())
+                .to_result()?
         }
         Ok(())
     }

--- a/crates/cust/src/memory/malloc.rs
+++ b/crates/cust/src/memory/malloc.rs
@@ -2,7 +2,7 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use super::DeviceCopy;
 use crate::error::*;
@@ -48,7 +48,7 @@ pub unsafe fn cuda_malloc<T: DeviceCopy>(count: usize) -> CudaResult<DevicePoint
     }
 
     let mut ptr = 0;
-    driver_sys::cuMemAlloc(&mut ptr, size).to_result()?;
+    driver::cuMemAlloc(&mut ptr, size).to_result()?;
     Ok(DevicePointer::from_raw(ptr))
 }
 
@@ -71,14 +71,14 @@ pub unsafe fn cuda_malloc_async<T: DeviceCopy>(
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    driver_sys::cuMemAllocAsync(
+    driver::cuMemAllocAsync(
         &mut ptr as *mut *mut c_void as *mut u64,
         size,
         stream.as_inner(),
     )
     .to_result()?;
     let ptr = ptr as *mut T;
-    Ok(DevicePointer::from_raw(ptr as driver_sys::CUdeviceptr))
+    Ok(DevicePointer::from_raw(ptr as driver::CUdeviceptr))
 }
 
 /// Unsafe wrapper around `cuMemFreeAsync` which queues a memory allocation free operation on a stream.
@@ -97,7 +97,7 @@ pub unsafe fn cuda_free_async<T: DeviceCopy>(
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    driver_sys::cuMemFreeAsync(p.as_raw(), stream.as_inner()).to_result()
+    driver::cuMemFreeAsync(p.as_raw(), stream.as_inner()).to_result()
 }
 
 /// Unsafe wrapper around the `cuMemAllocManaged` function, which allocates some unified memory and
@@ -140,10 +140,10 @@ pub unsafe fn cuda_malloc_unified<T: DeviceCopy>(count: usize) -> CudaResult<Uni
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    driver_sys::cuMemAllocManaged(
+    driver::cuMemAllocManaged(
         &mut ptr as *mut *mut c_void as *mut u64,
         size,
-        driver_sys::CUmemAttach_flags_enum::CU_MEM_ATTACH_GLOBAL as u32,
+        driver::CUmemAttach_flags_enum::CU_MEM_ATTACH_GLOBAL as u32,
     )
     .to_result()?;
     let ptr = ptr as *mut T;
@@ -203,8 +203,7 @@ pub unsafe fn cuda_malloc_pitched<T: DeviceCopy>(
 
     let mut ptr = 0;
     let mut pitch = 0;
-    driver_sys::cuMemAllocPitch(&mut ptr, &mut pitch, width_bytes, height, element_size)
-        .to_result()?;
+    driver::cuMemAllocPitch(&mut ptr, &mut pitch, width_bytes, height, element_size).to_result()?;
     Ok((DevicePointer::from_raw(ptr), pitch))
 }
 
@@ -236,7 +235,7 @@ pub unsafe fn cuda_free<T: DeviceCopy>(ptr: DevicePointer<T>) -> CudaResult<()> 
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    driver_sys::cuMemFree(ptr.as_raw()).to_result()?;
+    driver::cuMemFree(ptr.as_raw()).to_result()?;
     Ok(())
 }
 
@@ -269,7 +268,7 @@ pub unsafe fn cuda_free_unified<T: DeviceCopy>(mut p: UnifiedPointer<T>) -> Cuda
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    driver_sys::cuMemFree(ptr as u64).to_result()?;
+    driver::cuMemFree(ptr as u64).to_result()?;
     Ok(())
 }
 
@@ -311,7 +310,7 @@ pub unsafe fn cuda_malloc_locked<T>(count: usize) -> CudaResult<*mut T> {
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    driver_sys::cuMemAllocHost(&mut ptr as *mut *mut c_void, size).to_result()?;
+    driver::cuMemAllocHost(&mut ptr as *mut *mut c_void, size).to_result()?;
     let ptr = ptr as *mut T;
     Ok(ptr)
 }
@@ -344,7 +343,7 @@ pub unsafe fn cuda_free_locked<T>(ptr: *mut T) -> CudaResult<()> {
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    driver_sys::cuMemFreeHost(ptr as *mut c_void).to_result()?;
+    driver::cuMemFreeHost(ptr as *mut c_void).to_result()?;
     Ok(())
 }
 

--- a/crates/cust/src/memory/mod.rs
+++ b/crates/cust/src/memory/mod.rs
@@ -97,7 +97,7 @@ pub use cust_core::_hidden::DeviceCopy;
 
 use std::ffi::c_void;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 /// A trait describing a generic buffer that can be accessed from the GPU. This could be either a [`UnifiedBuffer`]
 /// or a regular [`DeviceBuffer`].
@@ -149,14 +149,14 @@ impl<T: DeviceCopy> GpuBox<T> for UnifiedBox<T> {
 /// a size, used to be generic over DeviceBox, DeviceBuffer, DeviceVariable etc.
 pub trait DeviceMemory {
     /// Get the raw cuda device pointer
-    fn as_raw_ptr(&self) -> driver_sys::CUdeviceptr;
+    fn as_raw_ptr(&self) -> driver::CUdeviceptr;
 
     /// Get the size of the memory region in bytes
     fn size_in_bytes(&self) -> usize;
 }
 
 impl<T: DeviceCopy> DeviceMemory for DeviceBox<T> {
-    fn as_raw_ptr(&self) -> driver_sys::CUdeviceptr {
+    fn as_raw_ptr(&self) -> driver::CUdeviceptr {
         self.as_device_ptr().as_raw()
     }
 
@@ -166,7 +166,7 @@ impl<T: DeviceCopy> DeviceMemory for DeviceBox<T> {
 }
 
 impl<T: DeviceCopy> DeviceMemory for DeviceVariable<T> {
-    fn as_raw_ptr(&self) -> driver_sys::CUdeviceptr {
+    fn as_raw_ptr(&self) -> driver::CUdeviceptr {
         self.as_device_ptr().as_raw()
     }
 
@@ -176,7 +176,7 @@ impl<T: DeviceCopy> DeviceMemory for DeviceVariable<T> {
 }
 
 impl<T: DeviceCopy> DeviceMemory for DeviceBuffer<T> {
-    fn as_raw_ptr(&self) -> driver_sys::CUdeviceptr {
+    fn as_raw_ptr(&self) -> driver::CUdeviceptr {
         self.as_device_ptr().as_raw()
     }
 
@@ -186,7 +186,7 @@ impl<T: DeviceCopy> DeviceMemory for DeviceBuffer<T> {
 }
 
 impl<T: DeviceCopy> DeviceMemory for DeviceSlice<T> {
-    fn as_raw_ptr(&self) -> driver_sys::CUdeviceptr {
+    fn as_raw_ptr(&self) -> driver::CUdeviceptr {
         self.as_device_ptr().as_raw()
     }
 
@@ -208,11 +208,11 @@ mod private {
 /// Simple wrapper over cuMemcpyHtoD
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn memcpy_htod(
-    d_ptr: driver_sys::CUdeviceptr,
+    d_ptr: driver::CUdeviceptr,
     src_ptr: *const c_void,
     size: usize,
 ) -> CudaResult<()> {
-    driver_sys::cuMemcpyHtoD(d_ptr, src_ptr, size).to_result()?;
+    driver::cuMemcpyHtoD(d_ptr, src_ptr, size).to_result()?;
     Ok(())
 }
 
@@ -220,10 +220,10 @@ pub unsafe fn memcpy_htod(
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn memcpy_dtoh(
     d_ptr: *mut c_void,
-    src_ptr: driver_sys::CUdeviceptr,
+    src_ptr: driver::CUdeviceptr,
     size: usize,
 ) -> CudaResult<()> {
-    driver_sys::cuMemcpyDtoH(d_ptr, src_ptr, size).to_result()?;
+    driver::cuMemcpyDtoH(d_ptr, src_ptr, size).to_result()?;
     Ok(())
 }
 
@@ -284,32 +284,32 @@ pub unsafe fn memcpy_2d_htod<T: DeviceCopy>(
     width: usize,
     height: usize,
 ) -> CudaResult<()> {
-    use cust_raw::driver_sys::CUmemorytype;
+    use cust_raw::driver::CUmemorytype;
 
     let width_in_bytes = width
         .checked_mul(std::mem::size_of::<T>())
         .ok_or(CudaError::InvalidMemoryAllocation)?;
 
-    let pcopy = driver_sys::CUDA_MEMCPY2D_st {
+    let pcopy = driver::CUDA_MEMCPY2D_st {
         srcXInBytes: 0,
         srcY: 0,
         srcMemoryType: CUmemorytype::CU_MEMORYTYPE_HOST,
         srcHost: src as *const c_void,
-        srcDevice: 0,                                             // Ignored
-        srcArray: std::ptr::null_mut::<driver_sys::CUarray_st>(), // Ignored
+        srcDevice: 0,                                         // Ignored
+        srcArray: std::ptr::null_mut::<driver::CUarray_st>(), // Ignored
         srcPitch: spitch,
         dstXInBytes: 0,
         dstY: 0,
         dstMemoryType: CUmemorytype::CU_MEMORYTYPE_DEVICE,
         dstHost: std::ptr::null_mut::<c_void>(), // Ignored
         dstDevice: dst.as_raw(),
-        dstArray: std::ptr::null_mut::<driver_sys::CUarray_st>(), // Ignored
+        dstArray: std::ptr::null_mut::<driver::CUarray_st>(), // Ignored
         dstPitch: dpitch,
         WidthInBytes: width_in_bytes,
         Height: height,
     };
 
-    driver_sys::cuMemcpy2D(&pcopy).to_result()?;
+    driver::cuMemcpy2D(&pcopy).to_result()?;
     Ok(())
 }
 
@@ -370,32 +370,32 @@ pub unsafe fn memcpy_2d_dtoh<T: DeviceCopy>(
     width: usize,
     height: usize,
 ) -> CudaResult<()> {
-    use cust_raw::driver_sys::CUmemorytype;
+    use cust_raw::driver::CUmemorytype;
 
     let width_in_bytes = width
         .checked_mul(std::mem::size_of::<T>())
         .ok_or(CudaError::InvalidMemoryAllocation)?;
 
-    let pcopy = driver_sys::CUDA_MEMCPY2D_st {
+    let pcopy = driver::CUDA_MEMCPY2D_st {
         srcXInBytes: 0,
         srcY: 0,
         srcMemoryType: CUmemorytype::CU_MEMORYTYPE_DEVICE,
         srcHost: std::ptr::null_mut::<c_void>(), // Ignored
         srcDevice: src.as_raw(),
-        srcArray: std::ptr::null_mut::<driver_sys::CUarray_st>(), // Ignored
+        srcArray: std::ptr::null_mut::<driver::CUarray_st>(), // Ignored
         srcPitch: spitch,
         dstXInBytes: 0,
         dstY: 0,
         dstMemoryType: CUmemorytype::CU_MEMORYTYPE_HOST,
         dstHost: dst as *mut c_void,
-        dstDevice: 0,                                             // Ignored
-        dstArray: std::ptr::null_mut::<driver_sys::CUarray_st>(), // Ignored
+        dstDevice: 0,                                         // Ignored
+        dstArray: std::ptr::null_mut::<driver::CUarray_st>(), // Ignored
         dstPitch: dpitch,
         WidthInBytes: width_in_bytes,
         Height: height,
     };
 
-    driver_sys::cuMemcpy2D(&pcopy).to_result()?;
+    driver::cuMemcpy2D(&pcopy).to_result()?;
     Ok(())
 }
 
@@ -409,7 +409,7 @@ pub fn mem_get_info() -> CudaResult<(usize, usize)> {
     let mut mem_free = 0;
     let mut mem_total = 0;
     unsafe {
-        driver_sys::cuMemGetInfo(&mut mem_free, &mut mem_total).to_result()?;
+        driver::cuMemGetInfo(&mut mem_free, &mut mem_total).to_result()?;
     }
     Ok((mem_free, mem_total))
 }

--- a/crates/cust/src/memory/pointer.rs
+++ b/crates/cust/src/memory/pointer.rs
@@ -7,7 +7,7 @@ use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::mem::size_of;
 
-use cust_raw::driver_sys::CUdeviceptr;
+use cust_raw::driver::CUdeviceptr;
 
 use crate::memory::DeviceCopy;
 /// A pointer to device memory.

--- a/crates/cust/src/memory/unified.rs
+++ b/crates/cust/src/memory/unified.rs
@@ -8,7 +8,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::slice;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use super::DeviceCopy;
 use crate::device::Device;
@@ -640,8 +640,8 @@ pub trait MemoryAdvise<T: DeviceCopy>: private::Sealed {
         let mem_size = std::mem::size_of_val(slice);
 
         unsafe {
-            driver_sys::cuMemPrefetchAsync(
-                slice.as_ptr() as driver_sys::CUdeviceptr,
+            driver::cuMemPrefetchAsync(
+                slice.as_ptr() as driver::CUdeviceptr,
                 mem_size,
                 -1, // CU_DEVICE_CPU #define
                 stream.as_inner(),
@@ -677,8 +677,8 @@ pub trait MemoryAdvise<T: DeviceCopy>: private::Sealed {
         let mem_size = std::mem::size_of_val(slice);
 
         unsafe {
-            driver_sys::cuMemPrefetchAsync(
-                slice.as_ptr() as driver_sys::CUdeviceptr,
+            driver::cuMemPrefetchAsync(
+                slice.as_ptr() as driver::CUdeviceptr,
                 mem_size,
                 device.as_raw(),
                 stream.as_inner(),
@@ -703,19 +703,14 @@ pub trait MemoryAdvise<T: DeviceCopy>: private::Sealed {
         let mem_size = std::mem::size_of_val(slice);
 
         let advice = if read_mostly {
-            driver_sys::CUmem_advise::CU_MEM_ADVISE_SET_READ_MOSTLY
+            driver::CUmem_advise::CU_MEM_ADVISE_SET_READ_MOSTLY
         } else {
-            driver_sys::CUmem_advise::CU_MEM_ADVISE_UNSET_READ_MOSTLY
+            driver::CUmem_advise::CU_MEM_ADVISE_UNSET_READ_MOSTLY
         };
 
         unsafe {
-            driver_sys::cuMemAdvise(
-                slice.as_ptr() as driver_sys::CUdeviceptr,
-                mem_size,
-                advice,
-                0,
-            )
-            .to_result()?;
+            driver::cuMemAdvise(slice.as_ptr() as driver::CUdeviceptr, mem_size, advice, 0)
+                .to_result()?;
         }
         Ok(())
     }
@@ -744,10 +739,10 @@ pub trait MemoryAdvise<T: DeviceCopy>: private::Sealed {
         let mem_size = std::mem::size_of_val(slice);
 
         unsafe {
-            driver_sys::cuMemAdvise(
-                slice.as_ptr() as driver_sys::CUdeviceptr,
+            driver::cuMemAdvise(
+                slice.as_ptr() as driver::CUdeviceptr,
                 mem_size,
-                driver_sys::CUmem_advise::CU_MEM_ADVISE_SET_PREFERRED_LOCATION,
+                driver::CUmem_advise::CU_MEM_ADVISE_SET_PREFERRED_LOCATION,
                 preferred_location.map(|d| d.as_raw()).unwrap_or(-1),
             )
             .to_result()?;
@@ -761,10 +756,10 @@ pub trait MemoryAdvise<T: DeviceCopy>: private::Sealed {
         let mem_size = std::mem::size_of_val(slice);
 
         unsafe {
-            driver_sys::cuMemAdvise(
-                slice.as_ptr() as driver_sys::CUdeviceptr,
+            driver::cuMemAdvise(
+                slice.as_ptr() as driver::CUdeviceptr,
                 mem_size,
-                driver_sys::CUmem_advise::CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION,
+                driver::CUmem_advise::CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION,
                 0,
             )
             .to_result()?;

--- a/crates/cust/src/module.rs
+++ b/crates/cust/src/module.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_uint;
 use std::path::Path;
 use std::ptr;
 
-use cust_raw::driver_sys;
+use cust_raw::driver;
 
 use crate::error::{CudaResult, DropResult, ToResult};
 use crate::function::Function;
@@ -17,7 +17,7 @@ use crate::memory::{CopyDestination, DeviceCopy, DevicePointer};
 /// A compiled CUDA module, loaded into a context.
 #[derive(Debug)]
 pub struct Module {
-    inner: driver_sys::CUmodule,
+    inner: driver::CUmodule,
 }
 
 unsafe impl Send for Module {}
@@ -93,7 +93,7 @@ pub enum ModuleJitOption {
 }
 
 impl ModuleJitOption {
-    pub fn into_raw(opts: &[Self]) -> (Vec<driver_sys::CUjit_option>, Vec<*mut c_void>) {
+    pub fn into_raw(opts: &[Self]) -> (Vec<driver::CUjit_option>, Vec<*mut c_void>) {
         // And here we stumble across one of the most horrific things i have ever seen in my entire
         // journey of working with many parts of CUDA. As a background, CUDA usually wants an array
         // of pointers to values when it takes void**, after all, this is what is expected by anyone.
@@ -109,30 +109,30 @@ impl ModuleJitOption {
         for opt in opts {
             match opt {
                 Self::MaxRegisters(regs) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_MAX_REGISTERS);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_MAX_REGISTERS);
                     raw_vals.push(*regs as usize as *mut c_void);
                 }
                 Self::OptLevel(level) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_OPTIMIZATION_LEVEL);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_OPTIMIZATION_LEVEL);
                     raw_vals.push(*level as usize as *mut c_void);
                 }
                 Self::DetermineTargetFromContext => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_TARGET_FROM_CUCONTEXT);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_TARGET_FROM_CUCONTEXT);
                 }
                 Self::Target(target) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_TARGET);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_TARGET);
                     raw_vals.push(*target as usize as *mut c_void);
                 }
                 Self::Fallback(fallback) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_FALLBACK_STRATEGY);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_FALLBACK_STRATEGY);
                     raw_vals.push(*fallback as usize as *mut c_void);
                 }
                 Self::GenenerateDebugInfo(gen) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_GENERATE_DEBUG_INFO);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_GENERATE_DEBUG_INFO);
                     raw_vals.push(*gen as usize as *mut c_void);
                 }
                 Self::GenerateLineInfo(gen) => {
-                    raw_opts.push(driver_sys::CUjit_option::CU_JIT_GENERATE_LINE_INFO);
+                    raw_opts.push(driver::CUjit_option::CU_JIT_GENERATE_LINE_INFO);
                     raw_vals.push(*gen as usize as *mut c_void)
                 }
             }
@@ -181,8 +181,8 @@ impl Module {
             let mut module = Module {
                 inner: ptr::null_mut(),
             };
-            driver_sys::cuModuleLoad(
-                &mut module.inner as *mut driver_sys::CUmodule,
+            driver::cuModuleLoad(
+                &mut module.inner as *mut driver::CUmodule,
                 bytes.as_ptr() as *const _,
             )
             .to_result()?;
@@ -255,8 +255,8 @@ impl Module {
             inner: ptr::null_mut(),
         };
         let (mut options, mut option_values) = ModuleJitOption::into_raw(options);
-        driver_sys::cuModuleLoadDataEx(
-            &mut module.inner as *mut driver_sys::CUmodule,
+        driver::cuModuleLoadDataEx(
+            &mut module.inner as *mut driver::CUmodule,
             image,
             options.len() as c_uint,
             options.as_mut_ptr(),
@@ -349,8 +349,8 @@ impl Module {
             let mut module = Module {
                 inner: ptr::null_mut(),
             };
-            driver_sys::cuModuleLoadData(
-                &mut module.inner as *mut driver_sys::CUmodule,
+            driver::cuModuleLoadData(
+                &mut module.inner as *mut driver::CUmodule,
                 image.as_ptr() as *const c_void,
             )
             .to_result()?;
@@ -390,8 +390,8 @@ impl Module {
             let mut ptr: DevicePointer<T> = DevicePointer::null();
             let mut size: usize = 0;
 
-            driver_sys::cuModuleGetGlobal(
-                &mut ptr as *mut DevicePointer<T> as *mut driver_sys::CUdeviceptr,
+            driver::cuModuleGetGlobal(
+                &mut ptr as *mut DevicePointer<T> as *mut driver::CUdeviceptr,
                 &mut size as *mut usize,
                 self.inner,
                 name.as_ptr(),
@@ -427,10 +427,10 @@ impl Module {
         unsafe {
             let name = name.as_ref();
             let cstr = CString::new(name).expect("Argument to get_function had a nul");
-            let mut func: driver_sys::CUfunction = ptr::null_mut();
+            let mut func: driver::CUfunction = ptr::null_mut();
 
-            driver_sys::cuModuleGetFunction(
-                &mut func as *mut driver_sys::CUfunction,
+            driver::cuModuleGetFunction(
+                &mut func as *mut driver::CUfunction,
                 self.inner,
                 cstr.as_ptr(),
             )
@@ -473,7 +473,7 @@ impl Module {
 
         unsafe {
             let inner = mem::replace(&mut module.inner, ptr::null_mut());
-            match driver_sys::cuModuleUnload(inner).to_result() {
+            match driver::cuModuleUnload(inner).to_result() {
                 Ok(()) => {
                     mem::forget(module);
                     Ok(())
@@ -491,7 +491,7 @@ impl Drop for Module {
         unsafe {
             // No choice but to panic if this fails...
             let module = mem::replace(&mut self.inner, ptr::null_mut());
-            let _ = driver_sys::cuModuleUnload(module);
+            let _ = driver::cuModuleUnload(module);
         }
     }
 }
@@ -513,7 +513,7 @@ impl<T: DeviceCopy> CopyDestination<T> for Symbol<'_, T> {
         let size = mem::size_of::<T>();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyHtoD(self.ptr.as_raw(), val as *const T as *const c_void, size)
+                driver::cuMemcpyHtoD(self.ptr.as_raw(), val as *const T as *const c_void, size)
                     .to_result()?
             }
         }
@@ -524,7 +524,7 @@ impl<T: DeviceCopy> CopyDestination<T> for Symbol<'_, T> {
         let size = mem::size_of::<T>();
         if size != 0 {
             unsafe {
-                driver_sys::cuMemcpyDtoH(val as *const T as *mut c_void, self.ptr.as_raw(), size)
+                driver::cuMemcpyDtoH(val as *const T as *mut c_void, self.ptr.as_raw(), size)
                     .to_result()?
             }
         }

--- a/crates/cust/src/stream.rs
+++ b/crates/cust/src/stream.rs
@@ -15,8 +15,8 @@ use std::mem;
 use std::panic;
 use std::ptr;
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::{cudaError_enum, CUstream};
+use cust_raw::driver;
+use cust_raw::driver::{cudaError_enum, CUstream};
 
 use crate::error::{CudaResult, DropResult, ToResult};
 use crate::event::Event;
@@ -99,7 +99,7 @@ impl Stream {
             let mut stream = Stream {
                 inner: ptr::null_mut(),
             };
-            driver_sys::cuStreamCreateWithPriority(
+            driver::cuStreamCreateWithPriority(
                 &mut stream.inner as *mut CUstream,
                 flags.bits(),
                 priority.unwrap_or(0),
@@ -113,7 +113,7 @@ impl Stream {
     pub fn get_flags(&self) -> CudaResult<StreamFlags> {
         unsafe {
             let mut bits = 0u32;
-            driver_sys::cuStreamGetFlags(self.inner, &mut bits as *mut u32).to_result()?;
+            driver::cuStreamGetFlags(self.inner, &mut bits as *mut u32).to_result()?;
             Ok(StreamFlags::from_bits_truncate(bits))
         }
     }
@@ -141,7 +141,7 @@ impl Stream {
     pub fn get_priority(&self) -> CudaResult<i32> {
         unsafe {
             let mut priority = 0i32;
-            driver_sys::cuStreamGetPriority(self.inner, &mut priority as *mut i32).to_result()?;
+            driver::cuStreamGetPriority(self.inner, &mut priority as *mut i32).to_result()?;
             Ok(priority)
         }
     }
@@ -182,7 +182,7 @@ impl Stream {
         T: FnOnce(CudaResult<()>) + Send,
     {
         unsafe {
-            driver_sys::cuStreamAddCallback(
+            driver::cuStreamAddCallback(
                 self.inner,
                 Some(callback_wrapper::<T>),
                 Box::into_raw(callback) as *mut c_void,
@@ -215,7 +215,7 @@ impl Stream {
     /// # }
     /// ```
     pub fn synchronize(&self) -> CudaResult<()> {
-        unsafe { driver_sys::cuStreamSynchronize(self.inner).to_result() }
+        unsafe { driver::cuStreamSynchronize(self.inner).to_result() }
     }
 
     /// Make the stream wait on an event.
@@ -249,9 +249,7 @@ impl Stream {
     /// }
     /// ```
     pub fn wait_event(&self, event: &Event, flags: StreamWaitEventFlags) -> CudaResult<()> {
-        unsafe {
-            driver_sys::cuStreamWaitEvent(self.inner, event.as_inner(), flags.bits()).to_result()
-        }
+        unsafe { driver::cuStreamWaitEvent(self.inner, event.as_inner(), flags.bits()).to_result() }
     }
 
     // Hidden implementation detail function. Highly unsafe. Use the `launch!` macro instead.
@@ -271,7 +269,7 @@ impl Stream {
         let grid_size: GridSize = grid_size.into();
         let block_size: BlockSize = block_size.into();
 
-        driver_sys::cuLaunchKernel(
+        driver::cuLaunchKernel(
             func.to_raw(),
             grid_size.x,
             grid_size.y,
@@ -325,7 +323,7 @@ impl Stream {
 
         unsafe {
             let inner = mem::replace(&mut stream.inner, ptr::null_mut());
-            match driver_sys::cuStreamDestroy(inner).to_result() {
+            match driver::cuStreamDestroy(inner).to_result() {
                 Ok(()) => {
                     mem::forget(stream);
                     Ok(())
@@ -344,7 +342,7 @@ impl Drop for Stream {
         unsafe {
             let inner = mem::replace(&mut self.inner, ptr::null_mut());
 
-            let _ = driver_sys::cuStreamDestroy(inner);
+            let _ = driver::cuStreamDestroy(inner);
         }
     }
 }

--- a/crates/cust/src/surface.rs
+++ b/crates/cust/src/surface.rs
@@ -3,7 +3,7 @@ use std::{
     os::raw::c_ulonglong,
 };
 
-use cust_raw::driver_sys::{
+use cust_raw::driver::{
     cuSurfObjectCreate, cuSurfObjectDestroy, cuSurfObjectGetResourceDesc, CUsurfObject,
     CUDA_RESOURCE_DESC,
 };

--- a/crates/cust/src/texture.rs
+++ b/crates/cust/src/texture.rs
@@ -5,8 +5,8 @@ use std::os::raw::c_ulonglong;
 use std::os::raw::{c_float, c_uint};
 use std::ptr;
 
-use cust_raw::driver_sys;
-use cust_raw::driver_sys::{
+use cust_raw::driver;
+use cust_raw::driver::{
     cuTexObjectCreate, cuTexObjectDestroy, cuTexObjectGetResourceDesc,
     CUDA_RESOURCE_DESC_st__bindgen_ty_1, CUDA_RESOURCE_DESC_st__bindgen_ty_1__bindgen_ty_1,
     CUresourcetype, CUtexObject, CUDA_RESOURCE_DESC, CUDA_RESOURCE_VIEW_DESC, CUDA_TEXTURE_DESC,
@@ -46,11 +46,11 @@ bitflags::bitflags! {
     pub struct TextureDescriptorFlags: c_uint {
         /// Suppresses the default behavior of having the texture promote data to floating point data in the range
         /// of [0, 1]. This flag does nothing if the texture is a texture of `u32`s.
-        const READ_AS_INTEGER = driver_sys::CU_TRSF_READ_AS_INTEGER;
+        const READ_AS_INTEGER = driver::CU_TRSF_READ_AS_INTEGER;
         /// Suppresses the default behavior of having the texture coordinates range from [0, Dim], where Dim is the
         /// width or height of the CUDA array. Instead, the texture coordinates [0, 1] reference the entire array.
         /// This flag must be set if a mipmapped array is being used.
-        const NORMALIZED_COORDINATES = driver_sys::CU_TRSF_NORMALIZED_COORDINATES;
+        const NORMALIZED_COORDINATES = driver::CU_TRSF_NORMALIZED_COORDINATES;
         /// Disables any trilinear filtering optimizations. Trilinear optimizations improve texture filtering performance
         /// by allowing bilinear filtering on textures in scenarios where it can closely approximate the expected results.
         const DISABLE_TRILINEAR_OPTIMIZATION = 0x20; // cuda-sys doesnt have this for some reason?
@@ -111,17 +111,17 @@ impl TextureDescriptor {
         } = self;
         CUDA_TEXTURE_DESC {
             addressMode: unsafe {
-                transmute::<[TextureAdressingMode; 3], [driver_sys::CUaddress_mode_enum; 3]>(
+                transmute::<[TextureAdressingMode; 3], [driver::CUaddress_mode_enum; 3]>(
                     adress_modes,
                 )
             },
             filterMode: unsafe {
-                transmute::<TextureFilterMode, driver_sys::CUfilter_mode_enum>(filter_mode)
+                transmute::<TextureFilterMode, driver::CUfilter_mode_enum>(filter_mode)
             },
             flags: flags.bits(),
             maxAnisotropy: max_anisotropy,
             mipmapFilterMode: unsafe {
-                transmute::<TextureFilterMode, driver_sys::CUfilter_mode_enum>(mipmap_filter_mode)
+                transmute::<TextureFilterMode, driver::CUfilter_mode_enum>(mipmap_filter_mode)
             },
             mipmapLevelBias: mipmap_level_bias,
             minMipmapLevelClamp: min_mipmap_level_clamp,
@@ -301,7 +301,7 @@ impl ResourceViewDescriptor {
 
         CUDA_RESOURCE_VIEW_DESC {
             format: unsafe {
-                transmute::<ResourceViewFormat, driver_sys::CUresourceViewFormat_enum>(format)
+                transmute::<ResourceViewFormat, driver::CUresourceViewFormat_enum>(format)
             },
             width,
             height,
@@ -382,7 +382,7 @@ impl ResourceDescriptor {
     // TODO: evaluate if its possible to cause UB by making a raw descriptor with an invalid array handle.
     pub(crate) fn from_raw(raw: CUDA_RESOURCE_DESC) -> Self {
         match raw.resType {
-            driver_sys::CUresourcetype_enum::CU_RESOURCE_TYPE_ARRAY => Self {
+            driver::CUresourcetype_enum::CU_RESOURCE_TYPE_ARRAY => Self {
                 flags: ResourceDescriptorFlags::from_bits(raw.flags)
                     .expect("invalid resource descriptor flags"),
                 ty: ResourceType::Array {

--- a/crates/cust_raw/Cargo.toml
+++ b/crates/cust_raw/Cargo.toml
@@ -3,11 +3,14 @@ name = "cust_raw"
 version = "0.11.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Low level bindings to the CUDA Driver API"
+description = "Low level bindings to the CUDA Toolkit SDK"
 repository = "https://github.com/Rust-GPU/Rust-CUDA"
 readme = "../../README.md"
 links = "cuda"
 build = "build/main.rs"
+
+[dependencies]
+libc = { version = "0.2", optional = true }
 
 [build-dependencies]
 bindgen = "0.71.1"
@@ -19,9 +22,8 @@ features = [
     "driver",
     "runtime",
     "cublas",
-    "cublaslt",
-    "cublasxt",
-    "cudnn",
+    "cublasLt",
+    "cublasXt",
     "nvptx-compiler",
     "nvvm",
 ]
@@ -29,10 +31,15 @@ features = [
 [features]
 default = ["driver"]
 driver = []
-runtime = []
-cublas = []
-cublaslt = []
-cublasxt = []
-cudnn = []
+runtime = ["driver_types", "vector_types", "texture_types", "surface_types"]
+cuComplex = ["vector_types"]
+driver_types = []
+library_types = []
+surface_types = []
+texture_types = []
+vector_types = []
+cublas = ["runtime", "cuComplex", "library_types"]
+cublasLt = ["cublas", "libc"]
+cublasXt = ["cublas"]
 nvptx-compiler = []
 nvvm = []

--- a/crates/cust_raw/build/driver_wrapper.h
+++ b/crates/cust_raw/build/driver_wrapper.h
@@ -1,4 +1,2 @@
-#include "cuComplex.h"
 #include "cuda.h"
 #include "cudaProfiler.h"
-#include "vector_types.h"

--- a/crates/cust_raw/src/cublas/core.rs
+++ b/crates/cust_raw/src/cublas/core.rs
@@ -2,4 +2,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+use crate::types::complex::*;
+use crate::types::library::*;
+
+pub use crate::runtime::cudaStream_t;
+pub use crate::types::library::cudaDataType;
+
 include!(concat!(env!("OUT_DIR"), "/cublas_sys.rs"));

--- a/crates/cust_raw/src/cublas/lt.rs
+++ b/crates/cust_raw/src/cublas/lt.rs
@@ -1,5 +1,10 @@
-#![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+
+use libc::FILE;
+
+use crate::cublas::*;
+use crate::types::driver::*;
+use crate::types::library::*;
 
 include!(concat!(env!("OUT_DIR"), "/cublasLt_sys.rs"));

--- a/crates/cust_raw/src/cublas/mod.rs
+++ b/crates/cust_raw/src/cublas/mod.rs
@@ -1,0 +1,11 @@
+//! Bindings to the CUDA Basic Linear Algebra Subprograms (cuBLAS) library.
+
+pub use crate::types::complex::*;
+mod core;
+pub use core::*;
+
+#[cfg(feature = "cublasLt")]
+pub mod lt;
+
+#[cfg(feature = "cublasXt")]
+pub mod xt;

--- a/crates/cust_raw/src/cublas/xt.rs
+++ b/crates/cust_raw/src/cublas/xt.rs
@@ -2,4 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+use crate::cublas::*;
+use crate::types::complex::*;
+
 include!(concat!(env!("OUT_DIR"), "/cublasXt_sys.rs"));

--- a/crates/cust_raw/src/driver.rs
+++ b/crates/cust_raw/src/driver.rs
@@ -1,5 +1,7 @@
+//! Bindings to the CUDA Driver API
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-include!(concat!(env!("OUT_DIR"), "/runtime_sys.rs"));
+include!(concat!(env!("OUT_DIR"), "/driver_sys.rs"));

--- a/crates/cust_raw/src/driver_sys.rs
+++ b/crates/cust_raw/src/driver_sys.rs
@@ -1,5 +1,0 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-
-include!(concat!(env!("OUT_DIR"), "/driver_sys.rs"));

--- a/crates/cust_raw/src/lib.rs
+++ b/crates/cust_raw/src/lib.rs
@@ -1,16 +1,26 @@
+//! # `cust_raw`: Bindings to the CUDA Toolkit SDK
+//!
 #[cfg(feature = "driver")]
-pub mod driver_sys;
+pub mod driver;
+
 #[cfg(feature = "runtime")]
-pub mod runtime_sys;
+pub mod runtime;
+
+#[cfg(any(
+    feature = "driver_types",
+    feature = "vector_types",
+    feature = "texture_types",
+    feature = "surface_types",
+    feature = "cuComplex",
+    feature = "library_types"
+))]
+pub mod types;
 
 #[cfg(feature = "cublas")]
-pub mod cublas_sys;
-#[cfg(feature = "cublaslt")]
-pub mod cublaslt_sys;
-#[cfg(feature = "cublasxt")]
-pub mod cublasxt_sys;
+pub mod cublas;
 
 #[cfg(feature = "nvptx-compiler")]
-pub mod nvptx_compiler_sys;
+pub mod nvptx;
+
 #[cfg(feature = "nvvm")]
-pub mod nvvm_sys;
+pub mod nvvm;

--- a/crates/cust_raw/src/nvptx.rs
+++ b/crates/cust_raw/src/nvptx.rs
@@ -1,3 +1,5 @@
+//! Bindings to the NVPTX Compiler library.
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/crates/cust_raw/src/nvvm.rs
+++ b/crates/cust_raw/src/nvvm.rs
@@ -1,3 +1,6 @@
+//! Bindings to the libNVVM API, an interface for generating PTX code from both
+//! binary and text NVVM IR inputs.
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/crates/cust_raw/src/runtime.rs
+++ b/crates/cust_raw/src/runtime.rs
@@ -1,0 +1,11 @@
+//! Bindings to the CUDA Runtime API
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+pub use crate::types::driver::*;
+pub use crate::types::surface::*;
+pub use crate::types::texture::*;
+pub use crate::types::vector::dim3;
+
+include!(concat!(env!("OUT_DIR"), "/runtime_sys.rs"));

--- a/crates/cust_raw/src/types/complex.rs
+++ b/crates/cust_raw/src/types/complex.rs
@@ -1,0 +1,4 @@
+// Bindings to CUDA complex number types.
+#![allow(non_camel_case_types)]
+use crate::types::vector::*;
+include!(concat!(env!("OUT_DIR"), "/cuComplex_sys.rs"));

--- a/crates/cust_raw/src/types/driver.rs
+++ b/crates/cust_raw/src/types/driver.rs
@@ -1,0 +1,9 @@
+//! Bindings to driver types in the CUDA runtime API.
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(clippy::missing_safety_doc)]
+use crate::types::vector::dim3;
+include!(concat!(env!("OUT_DIR"), "/driver_types_sys.rs"));

--- a/crates/cust_raw/src/types/library.rs
+++ b/crates/cust_raw/src/types/library.rs
@@ -1,0 +1,3 @@
+//! Bindings to types used to query CUDA library properties.
+#![allow(non_camel_case_types)]
+include!(concat!(env!("OUT_DIR"), "/library_types_sys.rs"));

--- a/crates/cust_raw/src/types/mod.rs
+++ b/crates/cust_raw/src/types/mod.rs
@@ -1,0 +1,18 @@
+//! The CUDA runtime types bindings.
+#[cfg(feature = "driver_types")]
+pub mod driver;
+
+#[cfg(feature = "vector_types")]
+pub mod vector;
+
+#[cfg(feature = "texture_types")]
+pub mod texture;
+
+#[cfg(feature = "surface_types")]
+pub mod surface;
+
+#[cfg(feature = "cuComplex")]
+pub mod complex;
+
+#[cfg(feature = "library_types")]
+pub mod library;

--- a/crates/cust_raw/src/types/surface.rs
+++ b/crates/cust_raw/src/types/surface.rs
@@ -1,0 +1,5 @@
+//! Bindings to CUDA surface types.
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
+include!(concat!(env!("OUT_DIR"), "/surface_types_sys.rs"));

--- a/crates/cust_raw/src/types/texture.rs
+++ b/crates/cust_raw/src/types/texture.rs
@@ -1,0 +1,6 @@
+//! Bindings to CUDA texture types.
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+include!(concat!(env!("OUT_DIR"), "/texture_types_sys.rs"));

--- a/crates/cust_raw/src/types/vector.rs
+++ b/crates/cust_raw/src/types/vector.rs
@@ -1,0 +1,3 @@
+//! Binding to CUDA vector types.
+#![allow(non_camel_case_types)]
+include!(concat!(env!("OUT_DIR"), "/vector_types_sys.rs"));

--- a/crates/nvvm/src/lib.rs
+++ b/crates/nvvm/src/lib.rs
@@ -8,9 +8,9 @@ use std::{
     str::FromStr,
 };
 
-use cust_raw::nvvm_sys;
+use cust_raw::nvvm;
 
-pub use cust_raw::nvvm_sys::LIBDEVICE_BITCODE;
+pub use cust_raw::nvvm::LIBDEVICE_BITCODE;
 
 /// Get the major and minor NVVM IR version.
 pub fn ir_version() -> (i32, i32) {
@@ -20,7 +20,7 @@ pub fn ir_version() -> (i32, i32) {
         let mut major_dbg = MaybeUninit::uninit();
         let mut minor_dbg = MaybeUninit::uninit();
         // according to the docs this cant fail
-        let _ = nvvm_sys::nvvmIRVersion(
+        let _ = nvvm::nvvmIRVersion(
             major_ir.as_mut_ptr(),
             minor_ir.as_mut_ptr(),
             major_dbg.as_mut_ptr(),
@@ -38,7 +38,7 @@ pub fn dbg_version() -> (i32, i32) {
         let mut major_dbg = MaybeUninit::uninit();
         let mut minor_dbg = MaybeUninit::uninit();
         // according to the docs this cant fail
-        let _ = nvvm_sys::nvvmIRVersion(
+        let _ = nvvm::nvvmIRVersion(
             major_ir.as_mut_ptr(),
             minor_ir.as_mut_ptr(),
             major_dbg.as_mut_ptr(),
@@ -54,7 +54,7 @@ pub fn nvvm_version() -> (i32, i32) {
         let mut major = MaybeUninit::uninit();
         let mut minor = MaybeUninit::uninit();
         // according to the docs this cant fail
-        let _ = nvvm_sys::nvvmVersion(major.as_mut_ptr(), minor.as_mut_ptr());
+        let _ = nvvm::nvvmVersion(major.as_mut_ptr(), minor.as_mut_ptr());
         (major.assume_init(), minor.assume_init())
     }
 }
@@ -84,40 +84,40 @@ pub enum NvvmError {
 impl Display for NvvmError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
-            let ptr = nvvm_sys::nvvmGetErrorString(self.to_raw());
+            let ptr = nvvm::nvvmGetErrorString(self.to_raw());
             f.write_str(&CStr::from_ptr(ptr).to_string_lossy())
         }
     }
 }
 
 impl NvvmError {
-    fn to_raw(self) -> nvvm_sys::nvvmResult {
+    fn to_raw(self) -> nvvm::nvvmResult {
         match self {
-            NvvmError::CompilationError => nvvm_sys::nvvmResult::NVVM_ERROR_COMPILATION,
-            NvvmError::OutOfMemory => nvvm_sys::nvvmResult::NVVM_ERROR_OUT_OF_MEMORY,
+            NvvmError::CompilationError => nvvm::nvvmResult::NVVM_ERROR_COMPILATION,
+            NvvmError::OutOfMemory => nvvm::nvvmResult::NVVM_ERROR_OUT_OF_MEMORY,
             NvvmError::ProgramCreationFailure => {
-                nvvm_sys::nvvmResult::NVVM_ERROR_PROGRAM_CREATION_FAILURE
+                nvvm::nvvmResult::NVVM_ERROR_PROGRAM_CREATION_FAILURE
             }
-            NvvmError::IrVersionMismatch => nvvm_sys::nvvmResult::NVVM_ERROR_IR_VERSION_MISMATCH,
-            NvvmError::InvalidOption => nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_OPTION,
-            NvvmError::InvalidInput => nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_INPUT,
-            NvvmError::InvalidIr => nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_IR,
-            NvvmError::NoModuleInProgram => nvvm_sys::nvvmResult::NVVM_ERROR_NO_MODULE_IN_PROGRAM,
+            NvvmError::IrVersionMismatch => nvvm::nvvmResult::NVVM_ERROR_IR_VERSION_MISMATCH,
+            NvvmError::InvalidOption => nvvm::nvvmResult::NVVM_ERROR_INVALID_OPTION,
+            NvvmError::InvalidInput => nvvm::nvvmResult::NVVM_ERROR_INVALID_INPUT,
+            NvvmError::InvalidIr => nvvm::nvvmResult::NVVM_ERROR_INVALID_IR,
+            NvvmError::NoModuleInProgram => nvvm::nvvmResult::NVVM_ERROR_NO_MODULE_IN_PROGRAM,
         }
     }
 
-    fn from_raw(result: nvvm_sys::nvvmResult) -> Self {
+    fn from_raw(result: nvvm::nvvmResult) -> Self {
         use NvvmError::*;
         match result {
-            nvvm_sys::nvvmResult::NVVM_ERROR_COMPILATION => CompilationError,
-            nvvm_sys::nvvmResult::NVVM_ERROR_OUT_OF_MEMORY => OutOfMemory,
-            nvvm_sys::nvvmResult::NVVM_ERROR_PROGRAM_CREATION_FAILURE => ProgramCreationFailure,
-            nvvm_sys::nvvmResult::NVVM_ERROR_IR_VERSION_MISMATCH => IrVersionMismatch,
-            nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_OPTION => InvalidOption,
-            nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_INPUT => InvalidInput,
-            nvvm_sys::nvvmResult::NVVM_ERROR_INVALID_IR => InvalidIr,
-            nvvm_sys::nvvmResult::NVVM_ERROR_NO_MODULE_IN_PROGRAM => NoModuleInProgram,
-            nvvm_sys::nvvmResult::NVVM_SUCCESS => panic!(),
+            nvvm::nvvmResult::NVVM_ERROR_COMPILATION => CompilationError,
+            nvvm::nvvmResult::NVVM_ERROR_OUT_OF_MEMORY => OutOfMemory,
+            nvvm::nvvmResult::NVVM_ERROR_PROGRAM_CREATION_FAILURE => ProgramCreationFailure,
+            nvvm::nvvmResult::NVVM_ERROR_IR_VERSION_MISMATCH => IrVersionMismatch,
+            nvvm::nvvmResult::NVVM_ERROR_INVALID_OPTION => InvalidOption,
+            nvvm::nvvmResult::NVVM_ERROR_INVALID_INPUT => InvalidInput,
+            nvvm::nvvmResult::NVVM_ERROR_INVALID_IR => InvalidIr,
+            nvvm::nvvmResult::NVVM_ERROR_NO_MODULE_IN_PROGRAM => NoModuleInProgram,
+            nvvm::nvvmResult::NVVM_SUCCESS => panic!(),
             _ => unreachable!(),
         }
     }
@@ -127,10 +127,10 @@ trait ToNvvmResult {
     fn to_result(self) -> Result<(), NvvmError>;
 }
 
-impl ToNvvmResult for nvvm_sys::nvvmResult {
+impl ToNvvmResult for nvvm::nvvmResult {
     fn to_result(self) -> Result<(), NvvmError> {
         let err = match self {
-            nvvm_sys::nvvmResult::NVVM_SUCCESS => return Ok(()),
+            nvvm::nvvmResult::NVVM_SUCCESS => return Ok(()),
             _ => NvvmError::from_raw(self),
         };
         Err(err)
@@ -296,13 +296,13 @@ impl Default for NvvmArch {
 }
 
 pub struct NvvmProgram {
-    raw: nvvm_sys::nvvmProgram,
+    raw: nvvm::nvvmProgram,
 }
 
 impl Drop for NvvmProgram {
     fn drop(&mut self) {
         unsafe {
-            nvvm_sys::nvvmDestroyProgram(&mut self.raw as *mut _)
+            nvvm::nvvmDestroyProgram(&mut self.raw as *mut _)
                 .to_result()
                 .expect("failed to destroy nvvm program");
         }
@@ -314,7 +314,7 @@ impl NvvmProgram {
     pub fn new() -> Result<Self, NvvmError> {
         unsafe {
             let mut raw = MaybeUninit::uninit();
-            nvvm_sys::nvvmCreateProgram(raw.as_mut_ptr()).to_result()?;
+            nvvm::nvvmCreateProgram(raw.as_mut_ptr()).to_result()?;
             Ok(Self {
                 raw: raw.assume_init(),
             })
@@ -334,13 +334,13 @@ impl NvvmProgram {
                 .map(|x| x.as_ptr().cast())
                 .collect::<Vec<_>>();
 
-            nvvm_sys::nvvmCompileProgram(self.raw, options.len() as i32, options_ptr.as_mut_ptr())
+            nvvm::nvvmCompileProgram(self.raw, options.len() as i32, options_ptr.as_mut_ptr())
                 .to_result()?;
             let mut size = 0;
-            nvvm_sys::nvvmGetCompiledResultSize(self.raw, &mut size as *mut usize as *mut _)
+            nvvm::nvvmGetCompiledResultSize(self.raw, &mut size as *mut usize as *mut _)
                 .to_result()?;
             let mut buf: Vec<u8> = Vec::with_capacity(size);
-            nvvm_sys::nvvmGetCompiledResult(self.raw, buf.as_mut_ptr().cast()).to_result()?;
+            nvvm::nvvmGetCompiledResult(self.raw, buf.as_mut_ptr().cast()).to_result()?;
             buf.set_len(size);
             // 𝖇𝖆𝖓𝖎𝖘𝖍 𝖙𝖍𝖞 𝖓𝖚𝖑
             buf.pop();
@@ -352,7 +352,7 @@ impl NvvmProgram {
     pub fn add_module(&self, bitcode: &[u8], name: String) -> Result<(), NvvmError> {
         unsafe {
             let cstring = CString::new(name).expect("module name with nul");
-            nvvm_sys::nvvmAddModuleToProgram(
+            nvvm::nvvmAddModuleToProgram(
                 self.raw,
                 bitcode.as_ptr().cast(),
                 bitcode.len(),
@@ -371,7 +371,7 @@ impl NvvmProgram {
     pub fn add_lazy_module(&self, bitcode: &[u8], name: String) -> Result<(), NvvmError> {
         unsafe {
             let cstring = CString::new(name).expect("module name with nul");
-            nvvm_sys::nvvmLazyAddModuleToProgram(
+            nvvm::nvvmLazyAddModuleToProgram(
                 self.raw,
                 bitcode.as_ptr().cast(),
                 bitcode.len(),
@@ -389,10 +389,10 @@ impl NvvmProgram {
     pub fn compiler_log(&self) -> Result<Option<String>, NvvmError> {
         unsafe {
             let mut size = MaybeUninit::uninit();
-            nvvm_sys::nvvmGetProgramLogSize(self.raw, size.as_mut_ptr()).to_result()?;
+            nvvm::nvvmGetProgramLogSize(self.raw, size.as_mut_ptr()).to_result()?;
             let size = size.assume_init();
             let mut buf: Vec<u8> = Vec::with_capacity(size);
-            nvvm_sys::nvvmGetProgramLog(self.raw, buf.as_mut_ptr().cast()).to_result()?;
+            nvvm::nvvmGetProgramLog(self.raw, buf.as_mut_ptr().cast()).to_result()?;
             buf.set_len(size);
             // 𝖇𝖆𝖓𝖎𝖘𝖍 𝖙𝖍𝖞 𝖓𝖚𝖑
             buf.pop();
@@ -404,7 +404,7 @@ impl NvvmProgram {
     /// Verify the program without actually compiling it. In the case of invalid IR, you can find
     /// more detailed error info by calling [`compiler_log`](Self::compiler_log).
     pub fn verify(&self) -> Result<(), NvvmError> {
-        unsafe { nvvm_sys::nvvmVerifyProgram(self.raw, 0, null_mut()).to_result() }
+        unsafe { nvvm::nvvmVerifyProgram(self.raw, 0, null_mut()).to_result() }
     }
 }
 

--- a/crates/optix-sys/build/main.rs
+++ b/crates/optix-sys/build/main.rs
@@ -57,7 +57,7 @@ fn create_optix_bindings(sdk: &optix_sdk::OptiXSdk, cuda_include_paths: &[path::
     let bindings = bindgen::Builder::default()
         .header("build/wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .raw_line("use cust_raw::driver_sys::*;")
+        .raw_line("use cust_raw::driver::*;")
         .clang_args(
             sdk.optix_include_paths()
                 .iter()

--- a/crates/optix/src/acceleration.rs
+++ b/crates/optix/src/acceleration.rs
@@ -16,7 +16,7 @@ use std::{
     marker::PhantomData,
 };
 
-use cust_raw::driver_sys::CUdeviceptr;
+use cust_raw::driver::CUdeviceptr;
 use mint::{RowMatrix3x4, Vector3};
 
 pub trait BuildInput: std::hash::Hash {

--- a/crates/ptx_compiler/src/lib.rs
+++ b/crates/ptx_compiler/src/lib.rs
@@ -3,15 +3,15 @@
 
 use std::mem::MaybeUninit;
 
-use cust_raw::nvptx_compiler_sys;
+use cust_raw::nvptx;
 
 trait ToResult {
     fn to_result(self) -> Result<(), NvptxError>;
 }
 
-impl ToResult for nvptx_compiler_sys::nvPTXCompileResult {
+impl ToResult for nvptx::nvPTXCompileResult {
     fn to_result(self) -> Result<(), NvptxError> {
-        use cust_raw::nvptx_compiler_sys::nvPTXCompileResult::*;
+        use cust_raw::nvptx::nvPTXCompileResult::*;
         match self {
             NVPTXCOMPILE_SUCCESS => Ok(()),
             NVPTXCOMPILE_ERROR_INVALID_INPUT => Err(NvptxError::InvalidInput),
@@ -45,7 +45,7 @@ pub enum NvptxError {
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct NvptxCompiler {
-    raw: nvptx_compiler_sys::nvPTXCompilerHandle,
+    raw: nvptx::nvPTXCompilerHandle,
 }
 
 impl NvptxCompiler {
@@ -55,12 +55,8 @@ impl NvptxCompiler {
         let mut raw = MaybeUninit::uninit();
 
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerCreate(
-                raw.as_mut_ptr(),
-                ptx.len(),
-                ptx.as_ptr().cast(),
-            )
-            .to_result()?;
+            nvptx::nvPTXCompilerCreate(raw.as_mut_ptr(), ptx.len(), ptx.as_ptr().cast())
+                .to_result()?;
             let raw = raw.assume_init();
             Ok(Self { raw })
         }
@@ -70,7 +66,7 @@ impl NvptxCompiler {
 impl Drop for NvptxCompiler {
     fn drop(&mut self) {
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerDestroy(&mut self.raw as *mut _)
+            nvptx::nvPTXCompilerDestroy(&mut self.raw as *mut _)
                 .to_result()
                 .expect("failed to destroy nvptx compiler");
         }
@@ -80,13 +76,13 @@ impl Drop for NvptxCompiler {
 #[derive(Debug)]
 pub struct CompilerFailure {
     pub error: NvptxError,
-    handle: nvptx_compiler_sys::nvPTXCompilerHandle,
+    handle: nvptx::nvPTXCompilerHandle,
 }
 
 impl Drop for CompilerFailure {
     fn drop(&mut self) {
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerDestroy(&mut self.handle as *mut _)
+            nvptx::nvPTXCompilerDestroy(&mut self.handle as *mut _)
                 .to_result()
                 .expect("failed to destroy nvptx compiler failure");
         }
@@ -97,11 +93,10 @@ impl CompilerFailure {
     pub fn error_log(&self) -> NvptxResult<String> {
         let mut size = MaybeUninit::uninit();
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerGetErrorLogSize(self.handle, size.as_mut_ptr())
-                .to_result()?;
+            nvptx::nvPTXCompilerGetErrorLogSize(self.handle, size.as_mut_ptr()).to_result()?;
             let size = size.assume_init();
             let mut vec = Vec::with_capacity(size);
-            nvptx_compiler_sys::nvPTXCompilerGetErrorLog(self.handle, vec.as_mut_ptr() as *mut i8)
+            nvptx::nvPTXCompilerGetErrorLog(self.handle, vec.as_mut_ptr() as *mut i8)
                 .to_result()?;
             vec.set_len(size);
             Ok(String::from_utf8_lossy(&vec).to_string())
@@ -113,13 +108,13 @@ impl CompilerFailure {
 #[derive(Debug)]
 pub struct CompiledProgram {
     pub cubin: Vec<u8>,
-    handle: nvptx_compiler_sys::nvPTXCompilerHandle,
+    handle: nvptx::nvPTXCompilerHandle,
 }
 
 impl Drop for CompiledProgram {
     fn drop(&mut self) {
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerDestroy(&mut self.handle as *mut _)
+            nvptx::nvPTXCompilerDestroy(&mut self.handle as *mut _)
                 .to_result()
                 .expect("failed to destroy nvptx compiled program");
         }
@@ -130,12 +125,10 @@ impl CompiledProgram {
     pub fn info_log(&self) -> NvptxResult<String> {
         let mut size = MaybeUninit::uninit();
         unsafe {
-            nvptx_compiler_sys::nvPTXCompilerGetInfoLogSize(self.handle, size.as_mut_ptr())
-                .to_result()?;
+            nvptx::nvPTXCompilerGetInfoLogSize(self.handle, size.as_mut_ptr()).to_result()?;
             let size = size.assume_init();
             let mut vec = Vec::with_capacity(size);
-            nvptx_compiler_sys::nvPTXCompilerGetInfoLog(self.handle, vec.as_mut_ptr() as *mut i8)
-                .to_result()?;
+            nvptx::nvPTXCompilerGetInfoLog(self.handle, vec.as_mut_ptr() as *mut i8).to_result()?;
             vec.set_len(size);
             Ok(String::from_utf8_lossy(&vec).to_string())
         }


### PR DESCRIPTION
- Allow list files instead of types/var/functions.
- Split out type headers from runtime/cublas to their own crate.
- Drop sys prefix from internal crates. (Hopefully we can still get ownership of cuda-sys, which would make the internal sys suffix redundant).

This restructures cust_raw to the following:
```
src/
├── cublas/        # Cublas and its extensions
│   ├── core.rs
│   ├── lt.rs
│   ├── mod.rs
│   └── xt.rs
├── types/         # Common CUDA Runtime types
│   ├── driver.rs
│   ├── library.rs
│   ├── mod.rs
│   ├── surface.rs
│   └── texture.rs
├── driver.rs
├── lib.rs
├── nvptx.rs
├── nvvm.rs
├── runtime.rs
```
This is a precursor to adding other CUDA library bindings, like nvJPEG and cudaFFT.