### PR TITLE
Use `MANIFEST_DIR` in build scripts

### DIFF
--- a/examples/cuda/gemm/build.rs
+++ b/examples/cuda/gemm/build.rs
@@ -8,7 +8,9 @@ fn main() {
     println!("cargo::rerun-if-changed=kernels");
 
     let out_path = path::PathBuf::from(env::var("OUT_DIR").unwrap());
-    CudaBuilder::new("kernels")
+    let manifest_dir = path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    CudaBuilder::new(manifest_dir.join("kernels"))
         .copy_to(out_path.join("kernels.ptx"))
         .build()
         .unwrap();

--- a/examples/cuda/path_tracer/build.rs
+++ b/examples/cuda/path_tracer/build.rs
@@ -4,12 +4,17 @@ use std::path;
 use cuda_builder::CudaBuilder;
 
 fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=kernels");
+
     let out_path = path::PathBuf::from(env::var("OUT_DIR").unwrap());
-    CudaBuilder::new("kernels")
+    let manifest_dir = path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    CudaBuilder::new(manifest_dir.join("kernels"))
         .copy_to(out_path.join("kernels.ptx"))
         .build()
         .unwrap();
-    CudaBuilder::new("kernels")
+    CudaBuilder::new(manifest_dir.join("kernels"))
         .copy_to(out_path.join("kernels_optix.ptx"))
         .build_args(&["--features", "optix"])
         .build()

--- a/examples/cuda/vecadd/build.rs
+++ b/examples/cuda/vecadd/build.rs
@@ -4,11 +4,13 @@ use std::path;
 use cuda_builder::CudaBuilder;
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=kernels");
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=kernels");
 
     let out_path = path::PathBuf::from(env::var("OUT_DIR").unwrap());
-    CudaBuilder::new("kernels")
+    let manifest_dir = path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    CudaBuilder::new(manifest_dir.join("kernels"))
         .copy_to(out_path.join("kernels.ptx"))
         .build()
         .unwrap();


### PR DESCRIPTION
This should be a no-op unless running `cargo` from a different location using `--manifest-path`.