### PR TITLE
Make constant memory opt-in, spill large statics to global memory

### DIFF
--- a/crates/cuda_builder/src/lib.rs
+++ b/crates/cuda_builder/src/lib.rs
@@ -130,6 +130,18 @@ pub struct CudaBuilder {
     ///
     /// `true` by default.
     pub override_libm: bool,
+    /// If `true`, the codegen will attempt to place `static` variables in CUDA's
+    /// constant memory, which is fast but limited in size (~64KB total across all
+    /// statics). The codegen avoids placing any single item too large, but it does not
+    /// track cumulative size. Exceeding the limit may cause `IllegalAddress` runtime
+    /// errors (CUDA error code: `700`).
+    ///
+    /// The default is `false`, which places all statics in global memory. This avoids
+    /// such errors but may reduce performance and use more general memory.
+    ///
+    /// Future versions may support smarter placement and user-controlled
+    /// packing/spilling strategies.
+    pub use_constant_memory_space: bool,
     /// Whether to generate any debug info and what level of info to generate.
     pub debug: DebugInfo,
     /// Additional arguments passed to cargo during `cargo build`.
@@ -155,6 +167,7 @@ impl CudaBuilder {
             emit: None,
             optix: false,
             override_libm: true,
+            use_constant_memory_space: false,
             debug: DebugInfo::None,
             build_args: vec![],
             final_module_path: None,
@@ -281,6 +294,22 @@ impl CudaBuilder {
     /// determinism in things like `rapier`, then it may be helpful to disable such a feature.
     pub fn override_libm(mut self, override_libm: bool) -> Self {
         self.override_libm = override_libm;
+        self
+    }
+
+    /// If `true`, the codegen will attempt to place `static` variables in CUDA's
+    /// constant memory, which is fast but limited in size (~64KB total across all
+    /// statics). The codegen avoids placing any single item too large, but it does not
+    /// track cumulative size. Exceeding the limit may cause `IllegalAddress` runtime
+    /// errors (CUDA error code: `700`).
+    ///
+    /// If `false`, all statics are placed in global memory. This avoids such errors but
+    /// may reduce performance and use more general memory.
+    ///
+    /// Future versions may support smarter placement and user-controlled
+    /// packing/spilling strategies.
+    pub fn use_constant_memory_space(mut self, use_constant_memory_space: bool) -> Self {
+        self.use_constant_memory_space = use_constant_memory_space;
         self
     }
 

--- a/crates/cuda_builder/src/lib.rs
+++ b/crates/cuda_builder/src/lib.rs
@@ -137,7 +137,10 @@ pub struct CudaBuilder {
     /// errors (CUDA error code: `700`).
     ///
     /// The default is `false`, which places all statics in global memory. This avoids
-    /// such errors but may reduce performance and use more general memory.
+    /// such errors but may reduce performance and use more general memory. When set to
+    /// `false`, you can still annotate `static` variables with
+    /// `#[cuda_std::address_space(constant)]` to place them in constant memory
+    /// manually. This option only affects automatic placement.
     ///
     /// Future versions may support smarter placement and user-controlled
     /// packing/spilling strategies.
@@ -304,7 +307,9 @@ impl CudaBuilder {
     /// errors (CUDA error code: `700`).
     ///
     /// If `false`, all statics are placed in global memory. This avoids such errors but
-    /// may reduce performance and use more general memory.
+    /// may reduce performance and use more general memory. You can still annotate
+    /// `static` variables with `#[cuda_std::address_space(constant)]` to place them in
+    /// constant memory manually as this option only affects automatic placement.
     ///
     /// Future versions may support smarter placement and user-controlled
     /// packing/spilling strategies.

--- a/crates/rustc_codegen_nvvm/src/builder.rs
+++ b/crates/rustc_codegen_nvvm/src/builder.rs
@@ -1154,18 +1154,7 @@ impl<'ll, 'tcx, 'a> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
 impl<'ll> StaticBuilderMethods for Builder<'_, 'll, '_> {
     fn get_static(&mut self, def_id: DefId) -> &'ll Value {
-        unsafe {
-            let mut g = self.cx.get_static(def_id);
-            let llty = self.val_ty(g);
-            let addrspace = AddressSpace(llvm::LLVMGetPointerAddressSpace(llty));
-            if addrspace != AddressSpace::DATA {
-                trace!("Remapping global address space of global {:?}", g);
-                let llty = llvm::LLVMGetElementType(llty);
-                let ty = self.type_ptr_to_ext(llty, AddressSpace::DATA);
-                g = llvm::LLVMBuildAddrSpaceCast(self.llbuilder, g, ty, unnamed());
-            }
-            g
-        }
+        self.cx.get_static(def_id)
     }
 }
 

--- a/crates/rustc_codegen_nvvm/src/context.rs
+++ b/crates/rustc_codegen_nvvm/src/context.rs
@@ -22,7 +22,7 @@ use rustc_errors::DiagMessage;
 use rustc_hash::FxHashMap;
 use rustc_middle::dep_graph::DepContext;
 use rustc_middle::ty::layout::{
-    FnAbiError, FnAbiOf, FnAbiRequest, HasTyCtxt, HasTypingEnv, LayoutError,
+    FnAbiError, FnAbiOf, FnAbiRequest, HasTyCtxt, HasTypingEnv, LayoutError, LayoutOf,
 };
 use rustc_middle::ty::layout::{FnAbiOfHelpers, LayoutOfHelpers};
 use rustc_middle::ty::{Ty, TypeVisitableExt};
@@ -39,6 +39,10 @@ use rustc_target::callconv::FnAbi;
 
 use rustc_target::spec::{HasTargetSpec, Target};
 use tracing::{debug, trace};
+
+/// "There is a total of 64 KB constant memory on a device."
+/// <https://docs.nvidia.com/cuda/archive/12.8.1/pdf/CUDA_C_Best_Practices_Guide.pdf>
+const CONSTANT_MEMORY_SIZE_LIMIT_BYTES: u64 = 64 * 1024;
 
 pub(crate) struct CodegenCx<'ll, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -267,7 +271,18 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
         }
 
         if !is_mutable && self.type_is_freeze(ty) {
-            AddressSpace(4)
+            let layout = self.layout_of(ty);
+            if layout.size.bytes() > CONSTANT_MEMORY_SIZE_LIMIT_BYTES {
+                self.tcx.sess.dcx().warn(format!(
+                    "static `{}` exceeds the constant-memory limit; placing in global memory (performance may be reduced)",
+                    instance
+                ));
+                // Global memory
+                AddressSpace(1)
+            } else {
+                // Constant memory
+                AddressSpace(4)
+            }
         } else {
             AddressSpace::DATA
         }


### PR DESCRIPTION
I've decided to default to not using constant memory with an opt-in flag. Later when we are smarter we can flip the flag by default and/or make it a no-op. One can still annotate code with `#[cuda_std::address_space(constant)]` to place it manually., this flag only affects automatic placement by the codegen backend.

Using this flag / turning on constant memory can blow up as constant memory placing logic isn't fully correct. Ideally we keep track of what we have put into constant memory and when it is filled up spill instead of only spilling when a static is too large on its own. We'll also probably want some packing strategy controlled by the user...for example, if you have one large static and many small ones, you might want the small ones to all be in constant memory or just the big one depending on your workload. We need some design work around this, and the design shouldn't require code to be annotated to support third party non-GPU-aware libraries.

But, this is materially better than what is there (which is a runtime error).

Fixes https://github.com/Rust-GPU/Rust-CUDA/issues/208.

See also the debugging and discussion in
https://github.com/Rust-GPU/Rust-CUDA/pull/216