### PR TITLE
Update Docker and CI for multi-architecture support

### DIFF
--- a/.github/workflows/container_images.yml
+++ b/.github/workflows/container_images.yml
@@ -29,16 +29,16 @@ jobs:
             arch: arm64
         variance:
           - name: Ubuntu-22.04/CUDA-11.8.0
-            image: "${{ github.repository }}-ubuntu22-cuda11"
+            image: "rust-gpu/rust-cuda-ubuntu22-cuda11"
             dockerfile: ./container/ubuntu22-cuda11/Dockerfile
           - name: Ubuntu-22.04/CUDA-12.8.1
-            image: "${{ github.repository }}-ubuntu22-cuda12"
+            image: "rust-gpu/rust-cuda-ubuntu22-cuda12"
             dockerfile: ./container/ubuntu22-cuda12/Dockerfile
           - name: Ubuntu-24.04/CUDA-12.8.1
-            image: "${{ github.repository }}-ubuntu24-cuda12"
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
             dockerfile: ./container/ubuntu24-cuda12/Dockerfile
           - name: RockyLinux-9/CUDA-12.8.1
-            image: "${{ github.repository }}-rockylinux9-cuda12"
+            image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
             dockerfile: ./container/rockylinux9-cuda12/Dockerfile
     steps:
       - name: Checkout repository
@@ -109,13 +109,13 @@ jobs:
       matrix:
         variance:
           - name: Ubuntu-22.04/CUDA-11.8.0
-            image: "${{ github.repository }}-ubuntu22-cuda11"
+            image: "rust-gpu/rust-cuda-ubuntu22-cuda11"
           - name: Ubuntu-22.04/CUDA-12.8.1
-            image: "${{ github.repository }}-ubuntu22-cuda12"
+            image: "rust-gpu/rust-cuda-ubuntu22-cuda12"
           - name: Ubuntu-24.04/CUDA-12.8.1
-            image: "${{ github.repository }}-ubuntu24-cuda12"
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
           - name: RockyLinux-9/CUDA-12.8.1
-            image: "${{ github.repository }}-rockylinux9-cuda12"
+            image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/container_images.yml
+++ b/.github/workflows/container_images.yml
@@ -14,16 +14,19 @@ env:
   REGISTRY: ghcr.io
 jobs:
   build-images:
-    name: ${{ matrix.variance.name }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.variance.name }} (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
         variance:
           - name: Ubuntu-22.04/CUDA-11.8.0
             image: "${{ github.repository }}-ubuntu22-cuda11"
@@ -40,6 +43,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Validate platform
+        run: |
+          ARCH=$(uname -m)
+          if [[ "${{ matrix.platform.arch }}" == "amd64" && "$ARCH" != "x86_64" ]]; then
+            echo "Error: Expected x86_64 but got $ARCH"
+            exit 1
+          fi
+          if [[ "${{ matrix.platform.arch }}" == "arm64" && "$ARCH" != "aarch64" ]]; then
+            echo "Error: Expected aarch64 but got $ARCH"
+            exit 1
+          fi
+          echo "Platform validation passed: $ARCH matches ${{ matrix.platform.arch }}"
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -51,24 +66,85 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.variance.image }}
-          tags: |
-            type=ref,event=branch
-            type=sha,format=short
-            type=raw,value=latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push container images
-        id: push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.variance.dockerfile }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.platform.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.variance.image }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ matrix.variance.image }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          name: digests-${{ matrix.variance.image }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
+    name: Create manifest for ${{ matrix.variance.name }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs: build-images
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variance:
+          - name: Ubuntu-22.04/CUDA-11.8.0
+            image: "${{ github.repository }}-ubuntu22-cuda11"
+          - name: Ubuntu-22.04/CUDA-12.8.1
+            image: "${{ github.repository }}-ubuntu22-cuda12"
+          - name: Ubuntu-24.04/CUDA-12.8.1
+            image: "${{ github.repository }}-ubuntu24-cuda12"
+          - name: RockyLinux-9/CUDA-12.8.1
+            image: "${{ github.repository }}-rockylinux9-cuda12"
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.variance.image }}-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.variance.image }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ matrix.variance.image }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ matrix.variance.image }}:${{ steps.meta.outputs.version }}

--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:12.8.1-cudnn-devel-rockylinux9
 
-RUN dnf -y install \
+RUN dnf -y update && \
+    dnf -y install \
     clang \
     openssl-devel \
     pkgconfig \
@@ -20,16 +21,50 @@ RUN dnf -y install \
     libXrandr-devel && \
     dnf clean all
 
-# Get LLVM 7 & libffi.so.6
+# Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/l/libffi3.1-3.1-36.el9.x86_64.rpm && \
-    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-7.0.1-7.el8.x86_64.rpm && \
-    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-devel-7.0.1-7.el8.x86_64.rpm && \
-    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-libs-7.0.1-7.el8.x86_64.rpm && \
-    curl -sSf -L -O https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/llvm7.0-static-7.0.1-7.el8.x86_64.rpm && \
-    dnf -y install ./*.rpm && \
-    ln -s /usr/bin/llvm-config-7-64 /usr/bin/llvm-config && \
-    rm -rf ./*.rpm && \
+
+# Install dependencies for building LLVM
+RUN dnf -y install epel-release && \
+    dnf -y install \
+    libffi-devel \
+    ncurses-devel \
+    libxml2-devel \
+    libedit-devel \
+    python3 \
+    ninja-build && \
+    dnf clean all
+
+# Download and build LLVM 7.1.0 for all architectures (consistency)
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        .. && \
+    ninja -j$(nproc) && \
+    ninja install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src* && \
+    ln -s /usr/bin/llvm-config /usr/bin/llvm-config-7 && \
     dnf clean all
 
 # Get Rust

--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -32,7 +32,7 @@ RUN dnf -y install epel-release && \
     libxml2-devel \
     libedit-devel \
     python3 \
-    ninja-build && \
+    ninja && \
     dnf clean all
 
 # Download and build LLVM 7.1.0 for all architectures (consistency)

--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -32,10 +32,10 @@ RUN dnf -y install epel-release && \
     libxml2-devel \
     libedit-devel \
     python3 \
-    ninja && \
+    make && \
     dnf clean all
 
-# Download and build LLVM 7.1.0 for all architectures (consistency)
+# Download and build LLVM 7.1.0 for all architectures
 RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
     tar -xf llvm-7.1.0.src.tar.xz && \
     cd llvm-7.1.0.src && \
@@ -46,7 +46,7 @@ RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmo
     else \
         TARGETS="AArch64;NVPTX"; \
     fi && \
-    cmake -G Ninja \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
         -DLLVM_BUILD_LLVM_DYLIB=ON \
@@ -60,8 +60,8 @@ RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmo
         -DLLVM_ENABLE_TERMINFO=ON \
         -DCMAKE_INSTALL_PREFIX=/usr \
         .. && \
-    ninja -j$(nproc) && \
-    ninja install && \
+    make -j$(nproc) && \
+    make install && \
     cd ../.. && \
     rm -rf llvm-7.1.0.src* && \
     ln -s /usr/bin/llvm-config /usr/bin/llvm-config-7 && \

--- a/container/ubuntu22-cuda11/Dockerfile
+++ b/container/ubuntu22-cuda11/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and build LLVM 7.1.0 for all architectures (consistency)
+# Download and build LLVM 7.1.0 for all architectures
 RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
     tar -xf llvm-7.1.0.src.tar.xz && \
     cd llvm-7.1.0.src && \

--- a/container/ubuntu22-cuda11/Dockerfile
+++ b/container/ubuntu22-cuda11/Dockerfile
@@ -24,14 +24,47 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
 
 # Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
-    apt-get update && apt-get install -y ./*.deb && \
-    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
-    rm -rf ./*.deb && \
+
+# Install dependencies for building LLVM
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    libffi-dev \
+    libedit-dev \
+    libncurses5-dev \
+    libxml2-dev \
+    python3 \
+    ninja-build && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and build LLVM 7.1.0 for all architectures (consistency)
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        .. && \
+    ninja -j$(nproc) && \
+    ninja install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src* && \
+    ln -s /usr/bin/llvm-config /usr/bin/llvm-config-7
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
@@ -46,3 +79,4 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-too
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info
+

--- a/container/ubuntu22-cuda12/Dockerfile
+++ b/container/ubuntu22-cuda12/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and build LLVM 7.1.0 for all architectures (consistency)
+# Download and build LLVM 7.1.0 for all architectures
 RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
     tar -xf llvm-7.1.0.src.tar.xz && \
     cd llvm-7.1.0.src && \

--- a/container/ubuntu22-cuda12/Dockerfile
+++ b/container/ubuntu22-cuda12/Dockerfile
@@ -24,14 +24,47 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
 
 # Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
-    apt-get update && apt-get install -y ./*.deb && \
-    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
-    rm -rf ./*.deb && \
+
+# Install dependencies for building LLVM
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    libffi-dev \
+    libedit-dev \
+    libncurses5-dev \
+    libxml2-dev \
+    python3 \
+    ninja-build && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and build LLVM 7.1.0 for all architectures (consistency)
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        .. && \
+    ninja -j$(nproc) && \
+    ninja install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src* && \
+    ln -s /usr/bin/llvm-config /usr/bin/llvm-config-7
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
@@ -46,3 +79,4 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-too
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info
+

--- a/container/ubuntu24-cuda12/Dockerfile
+++ b/container/ubuntu24-cuda12/Dockerfile
@@ -22,17 +22,49 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     libxrandr-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Get LLVM 7 & libffi7
+# Get LLVM 7
 WORKDIR /data/llvm7
-RUN curl -sSf -L -O http://security.ubuntu.com/ubuntu/pool/universe/libf/libffi7/libffi7_3.3-5ubuntu1_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-dev_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/libllvm7_7.0.1-12_amd64.deb && \
-    curl -sSf -L -O http://mirrors.kernel.org/ubuntu/pool/universe/l/llvm-toolchain-7/llvm-7-runtime_7.0.1-12_amd64.deb && \
-    apt-get install -y ./*.deb && \
-    ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config && \
-    rm -rf ./*.deb && \
+
+# Install dependencies for building LLVM
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    libffi-dev \
+    libedit-dev \
+    libncurses5-dev \
+    libxml2-dev \
+    python3 \
+    ninja-build && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and build LLVM 7.1.0 for all architectures (consistency)
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        .. && \
+    ninja -j$(nproc) && \
+    ninja install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src* && \
+    ln -s /usr/bin/llvm-config /usr/bin/llvm-config-7
 
 # Get Rust
 RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y
@@ -47,3 +79,4 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/Rust-CUDA/rust-too
 ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
 ENV LLVM_LINK_STATIC=1
 ENV RUST_LOG=info
+

--- a/container/ubuntu24-cuda12/Dockerfile
+++ b/container/ubuntu24-cuda12/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     ninja-build && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and build LLVM 7.1.0 for all architectures (consistency)
+# Download and build LLVM 7.1.0 for all architectures
 RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
     tar -xf llvm-7.1.0.src.tar.xz && \
     cd llvm-7.1.0.src && \


### PR DESCRIPTION
Build LLVM 7.1.0 from source for consistent versions across architectures. 7.1.0 is basically the same as 7.0.1.

Add native ARM64 runner support in GitHub Actions workflow.

Implement two-phase build process with manifest lists for multi-arch images.

Add build optimizations and caching to improve CI performance.