### PR TITLE
Fix warning when compiling rust wrapper C++

### DIFF
--- a/crates/rustc_codegen_nvvm/rustc_llvm_wrapper/RustWrapper.cpp
+++ b/crates/rustc_codegen_nvvm/rustc_llvm_wrapper/RustWrapper.cpp
@@ -40,7 +40,7 @@ using namespace llvm::object;
 
 // This opcode is an LLVM detail that could hypothetically change (?), so
 // verify that the hard-coded value in `dwarf_const.rs` still agrees with LLVM.
-static_assert(dwarf::DW_OP_LLVM_fragment == 0x1000);
+static_assert(dwarf::DW_OP_LLVM_fragment == 0x1000, "DW_OP_LLVM_fragment value mismatch");
 
 // LLVMAtomicOrdering is already an enum - don't create another
 // one.


### PR DESCRIPTION
This was output:
```
warning: rustc_codegen_nvvm@0.3.0:
  rustc_llvm_wrapper/RustWrapper.cpp:43:45: warning: 'static_assert'
  without a message only available with '-std=c++17' or '-std=gnu++17'
  [-Wc++17-extensions]
  warning: rustc_codegen_nvvm@0.3.0:    43
  static_assert(dwarf::DW_OP_LLVM_fragment == 0x1000);
```