### PR TITLE
Restrict CI on forks.

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - "**.md"
   push:
+    branches:
+      - main
     paths-ignore:
       - "**.md"
 


### PR DESCRIPTION
- Don't do Windows CI on forks. (We already don't do Linux CI on forks.)

- Don't do container image CI on forks. (We shouldn't be pushing container images to ghcr.io from forks!)

- Remove the `if` condition in `deploy_guide.yml`. It has no effct because there is an `on: push: branches: - main` condition higher up doing the same thing (and in the more typical way).