### PR TITLE
Restrict CI on forks, more.

### DIFF
--- a/.github/workflows/container_images.yml
+++ b/.github/workflows/container_images.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/container_images.yml"
       - "container/**"
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/container_images.yml"
       - "container/**"

--- a/.github/workflows/deploy_guide.yml
+++ b/.github/workflows/deploy_guide.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   deploy:
     # Only run on the main repository, not on forks
-    if: github.repository == 'rust-gpu/Rust-CUDA'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
- Don't do container image CI on forks. (We shouldn't be pushing container images to ghcr.io from forks!)

- Remove the `if` condition in `deploy_guide.yml`. It has no effct because there is an `on: push: branches: - main` condition higher up doing the same thing (and in the more typical way).

(These changes were supposed to be in #268, but I failed to commit the changes before pushing, sigh.)