### PR TITLE
Fixed 'is_i128', making it check if the type is an intiger, before casting it to check the intiger bit width

### DIFF
--- a/crates/rustc_codegen_nvvm/src/builder.rs
+++ b/crates/rustc_codegen_nvvm/src/builder.rs
@@ -1358,7 +1358,11 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
     // Helper function to check if a value is 128-bit integer
     fn is_i128(&self, val: &'ll Value) -> bool {
         let ty = self.val_ty(val);
-        unsafe { llvm::LLVMGetIntTypeWidth(ty) == 128 }
+        if unsafe { llvm::LLVMRustGetTypeKind(ty) == llvm::TypeKind::Integer } {
+            unsafe { llvm::LLVMGetIntTypeWidth(ty) == 128 }
+        } else {
+            false
+        }
     }
 
     // Helper to split i128 into low and high u64 parts

--- a/crates/rustc_codegen_nvvm/src/ty.rs
+++ b/crates/rustc_codegen_nvvm/src/ty.rs
@@ -237,7 +237,10 @@ impl<'ll, 'tcx> BaseTypeCodegenMethods for CodegenCx<'ll, 'tcx> {
     }
 
     fn int_width(&self, ty: &'ll Type) -> u64 {
-        unsafe { llvm::LLVMGetIntTypeWidth(ty) as u64 }
+        match self.type_kind(ty) {
+            TypeKind::Integer => unsafe { llvm::LLVMGetIntTypeWidth(ty) as u64 },
+            _ => bug!("llvm_int_width called on a non-integer type"),
+        }
     }
 
     fn val_ty(&self, v: &'ll Value) -> &'ll Type {


### PR DESCRIPTION
Small correctness fix: using  'is_i128' on non-int types is not correct, and will trigger LLVM assertions in debug mode. 

This PR makes us check if the type is an int first. 