### PR TITLE
Fix CI when codegen .so is clobbered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ opt-level = 3
 
 [workspace.dependencies]
 cuda_std = { path = "crates/cuda_std" }
-cuda_builder = { path = "crates/cuda_builder" }
+cuda_builder = { path = "crates/cuda_builder", default-features = false }

--- a/crates/cuda_builder/Cargo.toml
+++ b/crates/cuda_builder/Cargo.toml
@@ -8,8 +8,12 @@ description = "Builder for easily building rustc_codegen_nvvm crates"
 repository = "https://github.com/Rust-GPU/rust-cuda"
 readme = "../../README.md"
 
+[features]
+default = ["codegen-backend"]
+codegen-backend = ["rustc_codegen_nvvm"]
+
 [dependencies]
-rustc_codegen_nvvm = { version = "0.3", path = "../rustc_codegen_nvvm" }
+rustc_codegen_nvvm = { version = "0.3", path = "../rustc_codegen_nvvm", optional = true }
 nvvm = { path = "../nvvm", version = "0.1" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/crates/optix/examples/ex02_pipeline/Cargo.toml
+++ b/crates/optix/examples/ex02_pipeline/Cargo.toml
@@ -13,4 +13,4 @@ anyhow = "1.0.44"
 device = { path = "./device" }
 
 [build-dependencies]
-cuda_builder = { version = "0.3", path = "../../../cuda_builder" }
+cuda_builder = { workspace = true }

--- a/crates/optix/examples/ex04_mesh/Cargo.toml
+++ b/crates/optix/examples/ex04_mesh/Cargo.toml
@@ -15,4 +15,4 @@ num-traits = "0.2.14"
 glam = { version = "0.30", features = ["cuda"] }
 
 [build-dependencies]
-cuda_builder = { version = "0.3", path = "../../../cuda_builder" }
+cuda_builder = { workspace = true }

--- a/examples/cuda/gemm/Cargo.toml
+++ b/examples/cuda/gemm/Cargo.toml
@@ -13,4 +13,4 @@ ndarray-rand = "0.15.0"
 rand = "0.9"
 
 [build-dependencies]
-cuda_builder = { path = "../../../crates/cuda_builder" }
+cuda_builder = { workspace = true }

--- a/examples/cuda/path_tracer/Cargo.toml
+++ b/examples/cuda/path_tracer/Cargo.toml
@@ -23,4 +23,4 @@ sysinfo = "0.33.1"
 anyhow = "1.0.53"
 
 [build-dependencies]
-cuda_builder = { version = "0.3", path = "../../../crates/cuda_builder" }
+cuda_builder = { workspace = true }

--- a/examples/cuda/sha2_crates_io/Cargo.toml
+++ b/examples/cuda/sha2_crates_io/Cargo.toml
@@ -9,4 +9,4 @@ sha2_crates_io_kernels = { path = "kernels" }
 sha2 = "0.10"
 
 [build-dependencies]
-cuda_builder = { path = "../../../crates/cuda_builder" }
+cuda_builder = { workspace = true }

--- a/examples/cuda/vecadd/Cargo.toml
+++ b/examples/cuda/vecadd/Cargo.toml
@@ -8,4 +8,4 @@ cust = { path = "../../../crates/cust" }
 nanorand = "0.7"
 
 [build-dependencies]
-cuda_builder = { path = "../../../crates/cuda_builder" }
+cuda_builder = { workspace = true }


### PR DESCRIPTION
The workspace builds rustc_codegen_nvvm as a normal Cargo member. During every CUDA build script, cuda_builder re-builds that same crate through -Zcodegen-backend=. Cargo produces two identical librustc_codegen_nvvm.so.

cuda_builder then tried to copy the backend .so into target/codegen-backends while rustc_codegen_nvvm was still being linked. It sometimes read a half- written file.

Now cuda_builder still knows how to depend on rustc_codegen_nvvm, but that dependency lives behind a default feature. Inside the workspace we turn the default feature off so the backend is built exactly once as a regular workspace member.

External users get the same old behaviour because the feature defaults to on.

We also no longer blindly assume the .so already exists in cuda_builder. The build script is now more defensive.