### PR TITLE
Fixed a bug where self-referential types would cause infinite recursion and stack overflows

### DIFF
--- a/crates/rustc_codegen_nvvm/src/ty.rs
+++ b/crates/rustc_codegen_nvvm/src/ty.rs
@@ -611,8 +611,14 @@ fn struct_llfields<'a, 'tcx>(
             assert_eq!(offset.align_to(padding_align) + padding, target_offset);
             result.push(cx.type_padding_filler(padding, padding_align));
         }
+        match field.ty.kind() {
+            // This is a workaround for recursive types.
+            rustc_middle::ty::TyKind::FnPtr(_, _)
+            | rustc_middle::ty::TyKind::RawPtr(_, _)
+            | rustc_middle::ty::TyKind::Ref(_, _, _) => result.push(cx.type_i8p()),
+            _ => result.push(field.llvm_type(cx)),
+        }
 
-        result.push(field.llvm_type(cx));
         offset = target_offset + field.size;
         prev_effective_align = effective_field_align;
     }


### PR DESCRIPTION
As the title states. Currently, self-referential types would cause stack overflows(because if `Foo` contains a `Foo*`, then that creates an unsatisfiable cycle). 

This PR just uses `u8*` everywhere instead. Typed pointers are a relic of old LLVM, so getting rid of them(even if partially) now can only do us good. 