### PR TITLE
rustup: update to `nightly-2025-06-30`.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/abi.rs
+++ b/crates/rustc_codegen_nvvm/src/abi.rs
@@ -207,7 +207,12 @@ impl LlvmType for CastTarget {
                 "total size {:?} cannot be divided into units of zero size",
                 self.rest.total
             );
-            if self.rest.total.bytes() % self.rest.unit.size.bytes() != 0 {
+            if !self
+                .rest
+                .total
+                .bytes()
+                .is_multiple_of(self.rest.unit.size.bytes())
+            {
                 assert_eq!(
                     self.rest.unit.kind,
                     RegKind::Integer,

--- a/crates/rustc_codegen_nvvm/src/builder.rs
+++ b/crates/rustc_codegen_nvvm/src/builder.rs
@@ -1056,7 +1056,7 @@ impl<'ll, 'tcx, 'a> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         todo!()
     }
 
-    fn filter_landing_pad(&mut self, _pers_fn: &'ll Value) -> (&'ll Value, &'ll Value) {
+    fn filter_landing_pad(&mut self, _pers_fn: &'ll Value) {
         todo!()
     }
 

--- a/crates/rustc_codegen_nvvm/src/int_replace.rs
+++ b/crates/rustc_codegen_nvvm/src/int_replace.rs
@@ -77,7 +77,7 @@ pub(crate) fn get_transformed_type<'ll>(
 // going from i64 down.
 pub(crate) fn target_vector_width_and_count(int_width: u32) -> (u32, u32) {
     for &i in WIDTH_CANDIDATES {
-        if int_width % i == 0 {
+        if int_width.is_multiple_of(i) {
             return (i, int_width / i);
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-06-23"
+channel = "nightly-2025-06-30"
 components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
- `filter_landing_pad` no longer has a return value.
- `manual_is_multiple_of` clippy lint was enabled.