### PR TITLE
Update to `nightly-2025-07-07`.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/const_ty.rs
+++ b/crates/rustc_codegen_nvvm/src/const_ty.rs
@@ -152,7 +152,7 @@ impl<'ll, 'tcx> ConstCodegenMethods for CodegenCx<'ll, 'tcx> {
                 }
             }
             Scalar::Ptr(ptr, _) => {
-                let (prov, offset) = ptr.into_parts();
+                let (prov, offset) = ptr.prov_and_relative_offset();
                 let (base_addr, base_addr_space) = match self.tcx.global_alloc(prov.alloc_id()) {
                     GlobalAlloc::Memory(alloc) => {
                         // For ZSTs directly codegen an aligned pointer.

--- a/crates/rustc_codegen_nvvm/src/lib.rs
+++ b/crates/rustc_codegen_nvvm/src/lib.rs
@@ -3,7 +3,6 @@
 // make our lives a lot easier for llvm ffi with this. And since rustc's core infra
 // relies on it its almost guaranteed to not be removed/broken
 #![feature(extern_types)]
-#![feature(let_chains)]
 #![feature(slice_as_array)]
 
 extern crate rustc_abi;

--- a/crates/rustc_codegen_nvvm/src/ty.rs
+++ b/crates/rustc_codegen_nvvm/src/ty.rs
@@ -463,14 +463,6 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
                     .layout_of(ptr_ty)
                     .scalar_pair_element_llvm_type(cx, index, immediate);
             }
-            // `dyn* Trait` has the same ABI as `*mut dyn Trait`
-            ty::Dynamic(bounds, region, ty::DynStar) => {
-                let ptr_ty =
-                    Ty::new_mut_ptr(cx.tcx, Ty::new_dynamic(cx.tcx, bounds, *region, ty::Dyn));
-                return cx
-                    .layout_of(ptr_ty)
-                    .scalar_pair_element_llvm_type(cx, index, immediate);
-            }
             _ => {}
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-06-30"
+channel = "nightly-2025-07-07"
 components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
- `let_chains` is now a stable feature.
- `Pointer::into_parts` has been replaced with `Pointer::prov_and_relative_offset`.
- `DynStar` support has been removed (https://github.com/rust-lang/rust/pull/143036).