### PR TITLE
Update to nightly-2025-08-04.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/attributes.rs
+++ b/crates/rustc_codegen_nvvm/src/attributes.rs
@@ -1,7 +1,7 @@
 use crate::llvm::{self, AttributePlace::*, Value};
 use rustc_ast::{LitKind, MetaItemInner, MetaItemLit};
-use rustc_attr_data_structures::{InlineAttr, OptimizeAttr};
 use rustc_hir::Attribute;
+use rustc_hir::attrs::{InlineAttr, OptimizeAttr};
 use rustc_middle::{middle::codegen_fn_attrs::CodegenFnAttrFlags, ty};
 use rustc_session::{Session, config::OptLevel};
 use rustc_span::{Symbol, sym};

--- a/crates/rustc_codegen_nvvm/src/builder.rs
+++ b/crates/rustc_codegen_nvvm/src/builder.rs
@@ -1340,6 +1340,19 @@ impl<'ll, 'tcx, 'a> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         call
     }
 
+    fn tail_call(
+        &mut self,
+        _llty: Self::Type,
+        _fn_attrs: Option<&CodegenFnAttrs>,
+        _fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
+        _llfn: Self::Value,
+        _args: &[Self::Value],
+        _funclet: Option<&Self::Funclet>,
+        _instance: Option<ty::Instance<'tcx>>,
+    ) {
+        todo!()
+    }
+
     fn zext(&mut self, val: &'ll Value, dest_ty: &'ll Type) -> &'ll Value {
         trace!("Zext {:?} to {:?}", val, dest_ty);
         unsafe { llvm::LLVMBuildZExt(self.llbuilder, val, dest_ty, unnamed()) }

--- a/crates/rustc_codegen_nvvm/src/context.rs
+++ b/crates/rustc_codegen_nvvm/src/context.rs
@@ -260,7 +260,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     pub fn static_addrspace(&self, instance: Instance<'tcx>) -> AddressSpace {
         let ty = instance.ty(self.tcx, self.typing_env());
         let is_mutable = self.tcx().is_mutable_static(instance.def_id());
-        let attrs = self.tcx.get_attrs_unchecked(instance.def_id()); // TODO: replace with get_attrs
+        let attrs = self.tcx.get_all_attrs(instance.def_id()); // TODO: replace with get_attrs
         let nvvm_attrs = NvvmAttributes::parse(self, attrs);
 
         if let Some(addr) = nvvm_attrs.addrspace {

--- a/crates/rustc_codegen_nvvm/src/debug_info/mod.rs
+++ b/crates/rustc_codegen_nvvm/src/debug_info/mod.rs
@@ -402,7 +402,7 @@ impl<'ll, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             // First, let's see if this is a method within an inherent impl. Because
             // if yes, we want to make the result subroutine DIE a child of the
             // subroutine's self-type.
-            if let Some(impl_def_id) = cx.tcx.impl_of_method(instance.def_id()) {
+            if let Some(impl_def_id) = cx.tcx.impl_of_assoc(instance.def_id()) {
                 // If the method does *not* belong to a trait, proceed
                 if cx.tcx.trait_id_of_impl(impl_def_id).is_none() {
                     let impl_self_ty = cx.tcx.instantiate_and_normalize_erasing_regions(

--- a/crates/rustc_codegen_nvvm/src/lib.rs
+++ b/crates/rustc_codegen_nvvm/src/lib.rs
@@ -8,7 +8,6 @@
 extern crate rustc_abi;
 extern crate rustc_arena;
 extern crate rustc_ast;
-extern crate rustc_attr_data_structures;
 extern crate rustc_attr_parsing;
 extern crate rustc_codegen_ssa;
 extern crate rustc_data_structures;
@@ -262,19 +261,6 @@ impl WriteBackendMethods for NvvmCodegenBackend {
     type TargetMachineError = String;
     type ThinData = ();
     type ThinBuffer = ThinBuffer;
-
-    fn run_link(
-        _cgcx: &CodegenContext<Self>,
-        _diag_handler: DiagCtxtHandle<'_>,
-        _modules: Vec<ModuleCodegen<Self::Module>>,
-    ) -> Result<ModuleCodegen<Self::Module>, FatalError> {
-        // TODO(Rdambrosio016):
-        // we can probably call the llvm codegen to do this, but cgcx
-        // is a codegen context of NvvmCodegenBackend not LlvmCodegenBackend
-        // and to make a new cgcx we need to make a new LlvmCodegenBackend which
-        // cannot be done through the API currently
-        todo!();
-    }
 
     fn run_and_optimize_fat_lto(
         _cgcx: &CodegenContext<Self>,

--- a/crates/rustc_codegen_nvvm/src/mono_item.rs
+++ b/crates/rustc_codegen_nvvm/src/mono_item.rs
@@ -90,7 +90,7 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
         attributes::from_fn_attrs(self, lldecl, instance);
 
         let def_id = instance.def_id();
-        let attrs = self.tcx.get_attrs_unchecked(def_id); // TODO: Replace with get_attrs
+        let attrs = self.tcx.get_all_attrs(def_id); // TODO: Replace with get_attrs
         let nvvm_attrs = NvvmAttributes::parse(self, attrs);
 
         unsafe {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-07-28"
+channel = "nightly-2025-08-04"
 components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt", "rust-analyzer"]

--- a/tests/compiletests/ui/dis/target_feature_base_cc.stderr
+++ b/tests/compiletests/ui/dis/target_feature_base_cc.stderr
@@ -17,7 +17,7 @@ $L__tmp1:
     .loc    1 38 5
     bra.uni    $L__tmp2;
 $L__tmp2:
-    .loc    2 2198 9
+    .loc    2 2200 9
     mov.u32     %r1, 1124204544;
     st.volatile.global.u32     [%rd2], %r1;
 $L__tmp3:


### PR DESCRIPTION
- `rustc_attr_data_structures` was moved to `rustc_hir::attrs`.
- `BuilderMethods::tail_call` was added. It's currently `todo!()`.
- `tcx.get_attrs_unchecked(...)` was replaced with `tcx.get_all_attrs(...)`.
- `TyCtxt::impl_of_method` was renamed `TyCtxt::impl_of_assoc`.
- `WriteBackendMethods::run_link` was removed as part of the removal of `-Zcombine-cgu`.
- Need to update `target_feature_base_cc.stderr` for another innocuous looking DWARF `.loc` entry change.