### PR TITLE
Update to nightly-2025-08-11.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/context.rs
+++ b/crates/rustc_codegen_nvvm/src/context.rs
@@ -725,10 +725,6 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for CodegenCx<'_, 'tcx> {
 }
 
 impl<'tcx> CoverageInfoBuilderMethods<'tcx> for CodegenCx<'_, 'tcx> {
-    fn init_coverage(&mut self, _instance: Instance<'tcx>) {
-        todo!()
-    }
-
     fn add_coverage(
         &mut self,
         _instance: Instance<'tcx>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-08-04"
+channel = "nightly-2025-08-11"
 components = ["clippy", "llvm-tools-preview", "rust-src", "rustc-dev", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
- `CoverageInfoBuilderMethods::init_coverage` was removed.
- The `ret_ptr` argument was added to `BuilderMethods::atomic_rmw`, see https://github.com/rust-lang/rust/pull/144192.