### PR TITLE
Add CUDA IPC functions

### DIFF
--- a/crates/cuda_std/src/rt/driver_types_sys.rs
+++ b/crates/cuda_std/src/rt/driver_types_sys.rs
@@ -387,3 +387,8 @@ pub struct CUevent_st {
     _unused: [u8; 0],
 }
 pub type cudaEvent_t = *mut CUevent_st;
+
+#[repr(C)]
+pub struct cudaIpcMemHandle_t {
+    pub reserved: [u8; 64],
+}

--- a/crates/cuda_std/src/rt/sys.rs
+++ b/crates/cuda_std/src/rt/sys.rs
@@ -51,4 +51,8 @@ extern "C" {
         shared_mem_size: c_uint,
     ) -> *mut c_void;
     pub fn cudaLaunchDeviceV2(parameter_buffer: *mut c_void, stream: cudaStream_t) -> cudaError_t;
+
+    pub fn cudaIpcGetMemHandle(handle: *mut cudaIpcMemHandle_t, dev_ptr: *mut c_void) -> cudaError_t;
+    pub fn cudaIpcOpenMemHandle(dev_ptr: *mut *mut c_void, handle: cudaIpcMemHandle_t, flags: u32) -> cudaError_t;
+    pub fn cudaIpcCloseMemHandle(dev_ptr: *mut c_void) -> cudaError_t;
 }


### PR DESCRIPTION
This PR exposes the functions `cudaIpcGetMemHandle`, `cudaIpcOpenMemHandle` and `cudaIpcCloseMemHandle`, it also adds the definition for `cudaIpcMemHandle_t`, which are required to share device memory pointers between processes. This can be helpful for cross-language IPC access, e.g., creating a CuPy array in Python and then accessing the values as a `tch::Tensor`.