### PR TITLE
Update README with current docker image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo build
 The distribution related Dockerfile are located in `container` folder.
 Taking ubuntu 24.04 as an example, run the following command in repository root:
 ```bash
-docker build -f ./container/ubuntu24/Dockerfile -t rust-cuda-ubuntu24 .
+docker build -f ./container/ubuntu24-cuda12/Dockerfile -t rust-cuda-ubuntu24 .
 docker run --rm --runtime=nvidia --gpus all -it rust-cuda-ubuntu24
 ```
 


### PR DESCRIPTION
./container/ubuntu24/Dockerfile is no longer an existing Docker directory in the repo.