### PR TITLE
Fix compiletest's `--target-arch` handling.

### DIFF
--- a/crates/rustc_codegen_nvvm/src/context.rs
+++ b/crates/rustc_codegen_nvvm/src/context.rs
@@ -673,9 +673,7 @@ impl CodegenArgs {
                 continue;
             }
 
-            if let Ok(flag) = NvvmOption::from_str(arg) {
-                cg_args.nvvm_options.push(flag);
-            } else if arg == "--override-libm" {
+            if arg == "--override-libm" {
                 cg_args.override_libm = true;
             } else if arg == "--use-constant-memory-space" {
                 cg_args.use_constant_memory_space = true;
@@ -714,6 +712,12 @@ impl CodegenArgs {
                 skip_next = true;
             } else if let Some(entry) = arg.strip_prefix("--disassemble-entry=") {
                 cg_args.disassemble = Some(DisassembleMode::Entry(entry.to_string()));
+            } else {
+                // Do this only after all the other flags above have been tried.
+                match NvvmOption::from_str(arg) {
+                    Ok(flag) => cg_args.nvvm_options.push(flag),
+                    Err(err) => panic!("{}", err),
+                }
             }
         }
 


### PR DESCRIPTION
compiletests lets you specify one or more target architectures. E.g. on CI we run this:
```
cargo run -p compiletests --release --no-default-features -- \
    --target-arch compute_61,compute_70,compute_90
```
While trying out various different target architectures, including invalid ones, I get strange results.

First, if the target arch has fewer than 8 chars (e.g. `--target-arch blah`), then nvvm panics:
```
thread 'rustc' panicked at crates/nvvm/src/lib.rs:246:38: byte
index 8 is out of bounds of `blah`
```

Second, if the target arch has 8 or more chars but is invalid, it is just ignored. This means invalid flags like `--target-arch compute_999` run, but just use the default target architecture.

This commit fixes the problems.
- Fix the slicing into the `-arch=` option to avoid the bounds panic.
- In `CodegenArgs::parse`, check for the `Err` case and panic instead of swallowing it. A panic isn't ideal, but it's much better than silently accepting and ignoring invalid input.
- Use a `String` instead of `&'static str` for the `Err` case, so the error message is more informative, i.e. it includes the bad flag value.

Also, the commit improves the `NvvmOption::from_str` test.
- Move inputs next to expected outputs, which makes it easier to read and update.
- Add the missing compute capabilities.
- Add some checks for invalid inputs.