### PR TITLE
Rebuild backend if it has changed between compiletest runs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ opt-level = 3
 [workspace.dependencies]
 cuda_std = { path = "crates/cuda_std" }
 cuda_builder = { path = "crates/cuda_builder", version = "=0.3.0", default-features = false }
+rustc_codegen_nvvm = { path = "crates/rustc_codegen_nvvm", version = "=0.3.0" }

--- a/tests/compiletests/Cargo.toml
+++ b/tests/compiletests/Cargo.toml
@@ -13,3 +13,4 @@ clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 cuda_builder = { workspace = true }
+rustc_codegen_nvvm = { workspace = true }


### PR DESCRIPTION
This matches what rust-gpu does:

https://github.com/Rust-GPU/rust-gpu/blob/b3eda4df9814b6176d3c0844eb67f70a22ebb378/tests/compiletests/Cargo.toml#L18