### PR TITLE
Fix rocky linux clang

### DIFF
--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -57,6 +57,7 @@ RUN dnf -y install \
     --nobest \
     --allowerasing \
     --setopt=install_weak_deps=False \
+    clang \
     openssl-devel \
     pkgconfig \
     which \


### PR DESCRIPTION
This got dropped in a previous commit and is making CI fail with:
```
--- stderr

  thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.71.1/lib.rs:604:27:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  stack backtrace:
     0: __rustc::rust_begin_unwind
               at /rustc/f34ba774c78ea32b7c40598b8ad23e75cdac42a6/library/std/src/panicking.rs:697:5
     1: core::panicking::panic_fmt
               at /rustc/f34ba774c78ea32b7c40598b8ad23e75cdac42a6/library/core/src/panicking.rs:75:14
     2: core::result::unwrap_failed
               at /rustc/f34ba774c78ea32b7c40598b8ad23e75cdac42a6/library/core/src/result.rs:1852:5
     3: core::result::Result<T,E>::expect
     4: bindgen::ensure_libclang_is_loaded::{{closure}}
     5: std::sync::once_lock::OnceLock<T>::get_or_init::{{closure}}
     6: std::sync::once_lock::OnceLock<T>::initialize::{{closure}}
     7: std::sync::poison::once::Once::call_once_force::{{closure}}
     8: std::sys::sync::once::futex::Once::call
               at /rustc/f34ba774c78ea32b7c40598b8ad23e75cdac42a6/library/std/src/sys/sync/once/futex.rs:178:21
     9: std::sync::poison::once::Once::call_once_force
    10: std::sync::once_lock::OnceLock<T>::initialize
    11: std::sync::once_lock::OnceLock<T>::get_or_try_init
    12: std::sync::once_lock::OnceLock<T>::get_or_init
    13: bindgen::ensure_libclang_is_loaded
    14: bindgen::Bindings::generate
    15: bindgen::Builder::generate
    16: build_script_main::create_cuda_driver_bindings
    17: build_script_main::main
    18: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```