### PR TITLE
Fix rocky linux builds by including deps

### DIFF
--- a/container/rockylinux9-cuda12/Dockerfile
+++ b/container/rockylinux9-cuda12/Dockerfile
@@ -59,6 +59,13 @@ RUN dnf -y install \
     --setopt=install_weak_deps=False \
     clang \
     openssl-devel \
+    fontconfig-devel \
+    libX11-devel \
+    libXcursor-devel \
+    libXi-devel \
+    libXrandr-devel \
+    libxml2-devel \
+    ncurses-devel \
     pkgconfig \
     which \
     xz \


### PR DESCRIPTION
I thought these were only needed for an example,
turns out they are needed during bindgen regardless.