### PR TITLE
Fix `gemm` example on CUDA 13.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "cuda_std",
  "cust",
  "cust_raw",
+ "gemm-kernels",
  "ndarray",
  "ndarray-rand",
  "rand 0.9.2",

--- a/examples/cuda/gemm/Cargo.toml
+++ b/examples/cuda/gemm/Cargo.toml
@@ -8,6 +8,7 @@ blastoff = { path = "../../../crates/blastoff" }
 cuda_std = { path = "../../../crates/cuda_std" }
 cust = { path = "../../../crates/cust" }
 cust_raw = { path = "../../../crates/cust_raw", features = ["driver"] }
+gemm-kernels = { path = "kernels" }
 ndarray = { version = "0.16", features = ["approx"] }
 ndarray-rand = "0.15.0"
 rand = "0.9"

--- a/examples/cuda/gemm/kernels/src/gemm_tiled.rs
+++ b/examples/cuda/gemm/kernels/src/gemm_tiled.rs
@@ -3,6 +3,8 @@ use cuda_std::address_space;
 use cuda_std::kernel;
 use cuda_std::thread;
 
+pub const TILE_SIZE: usize = 16;
+
 #[kernel]
 #[allow(improper_ctypes_definitions)]
 /// Tiled GEMM kernel for C = alpha * A * B + beta * C.
@@ -38,7 +40,6 @@ pub unsafe fn gemm_tiled(
     alpha: f32,
     beta: f32,
 ) {
-    const TILE_SIZE: usize = 16;
     const TILE_SIZE_2D: usize = TILE_SIZE * TILE_SIZE;
 
     // Shared GPU memory is modelled with `#[address_space(shared)] static mut`. Unlike normal

--- a/examples/cuda/gemm/kernels/src/lib.rs
+++ b/examples/cuda/gemm/kernels/src/lib.rs
@@ -2,4 +2,4 @@ mod gemm_naive;
 mod gemm_tiled;
 
 pub use crate::gemm_naive::gemm_naive;
-pub use crate::gemm_tiled::gemm_tiled;
+pub use crate::gemm_tiled::{TILE_SIZE, gemm_tiled};

--- a/examples/cuda/gemm/src/main.rs
+++ b/examples/cuda/gemm/src/main.rs
@@ -13,6 +13,7 @@ use cust::memory::CopyDestination as _;
 use cust::module;
 use cust::stream;
 use cust::util::SliceExt as _;
+use gemm_kernels::TILE_SIZE;
 use ndarray::Array;
 use ndarray_rand::RandomExt as _;
 use ndarray_rand::rand_distr::Uniform;
@@ -429,9 +430,6 @@ pub fn gemm_tiled(
     assert_eq!(mat_a.len(), m * k);
     assert_eq!(mat_b.len(), k * n);
     assert_eq!(mat_c.len(), m * n);
-
-    // These values must be aligned with the kernel code.
-    const TILE_SIZE: usize = 16;
 
     let kernel_cell = cell::LazyCell::new(|| {
         module


### PR DESCRIPTION
`#[address_space(shared)] static mut` is used to model GPU shared memory. It's a bit weird. In particular, GPU shared memory is uninitialized, but `static mut` requires an initializer in Rust. `gemm` uses a zero initialize, but this initializer is ignored by NVVM. At least, it was in CUDA 12.x, but in CUDA 13.0 the `gemm` example fails with this error:
```
thread 'rustc' panicked at crates/rustc_codegen_nvvm/src/nvvm.rs:120:9:
Malformed NVVM IR program rejected by libnvvm, dumping verifier log:

error: Error: : Global Variable `_ZN12gemm_kernels10gemm_tiled10gemm_tiled6TILE_A17hc9c66e758c373a7eE':
  context: @_ZN12gemm_kernels10gemm_tiled10gemm_tiled6TILE_A17hc9c66e758c373a7eE = internal unnamed_addr addrspace(3) global <{ [1024 x i8] }> zeroinitializer, align 4
  Shared variables can't be initialized
```
This memory looks like it's initialized to zero but isn't, and then is written and read normally. This is incredibly dodgy and very likely UB. The proper way to deal with uninitialized memory in Rust is with `MaybeUninit`, and there are strict rules around its used, e.g. writes must be done with `write` and `assume_init` must be used values after they are written.

This commit changes `gemm` to use `MaybeUninit` for the shared memory. This fixes the error on CUDA 13.0 and the example runs correctly.

(This is the only executed use of GPU shared memory in rust-cuda. There is a `shared_array!` macro defined but it's only used in a compiletest where it is compiled but not run. That macro is extremely dubious but I will deal with it in a separate PR because it's not necessary to get CUDA 13.0 working.)