### PR TITLE
Update CI platforms.

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -28,17 +28,17 @@ jobs:
       fail-fast: false
       matrix:
         variance:
-          - name: Ubuntu-22.04 / CUDA-12.8.1 / x86_64
-            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-            runner: ubuntu-latest
-          - name: Ubuntu-22.04 / CUDA-12.8.1 / ARM64
-            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-            runner: ubuntu-22.04-arm
           - name: Ubuntu-24.04 / CUDA-12.8.1 / x86_64
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
             runner: ubuntu-latest
           - name: Ubuntu-24.04 / CUDA-12.8.1 / ARM64
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
+            runner: ubuntu-24.04-arm
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / x86_64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
+            runner: ubuntu-latest
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / ARM64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
             runner: ubuntu-24.04-arm
           - name: RockyLinux-9 / CUDA-12.8.1 / x86_64
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
@@ -244,17 +244,17 @@ jobs:
       matrix:
         variance:
           # Must match the build job's matrix definition
-          - name: Ubuntu-22.04 / CUDA-12.8.1 / x86_64
-            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-            runner: ubuntu-latest
-          - name: Ubuntu-22.04 / CUDA-12.8.1 / ARM64
-            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu22-cuda12:latest"
-            runner: ubuntu-22.04-arm
           - name: Ubuntu-24.04 / CUDA-12.8.1 / x86_64
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
             runner: ubuntu-latest
           - name: Ubuntu-24.04 / CUDA-12.8.1 / ARM64
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
+            runner: ubuntu-24.04-arm
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / x86_64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
+            runner: ubuntu-latest
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / ARM64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
             runner: ubuntu-24.04-arm
     steps:
       - name: Compute artifact name

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -23,23 +23,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            cuda: "12.8.1"
-            linux-local-args: []
-            sub-packages:
-              [
-                "nvcc",
-                "nvrtc",
-                "nvrtc_dev",
-                "cuda_profiler_api",
-                "cudart",
-                "cublas",
-                "cublas_dev",
-                "curand",
-                "curand_dev",
-              ]
+        os: windows-latest
+        target: x86_64-pc-windows-msvc
+        cuda: ["12.8.1", "13.0.2"]
+        linux-local-args: []
+        sub-packages:
+          [
+            "nvcc",
+            "nvrtc",
+            "nvrtc_dev",
+            "cuda_profiler_api",
+            "cudart",
+            "cublas",
+            "cublas_dev",
+            "curand",
+            "curand_dev",
+          ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/container_images.yml
+++ b/.github/workflows/container_images.yml
@@ -30,12 +30,12 @@ jobs:
           - runner: ubuntu-24.04-arm
             arch: arm64
         variance:
-          - name: Ubuntu-22.04/CUDA-12.8.1
-            image: "rust-gpu/rust-cuda-ubuntu22-cuda12"
-            dockerfile: ./container/ubuntu22-cuda12/Dockerfile
           - name: Ubuntu-24.04/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
             dockerfile: ./container/ubuntu24-cuda12/Dockerfile
+          - name: Ubuntu-24.04/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda13"
+            dockerfile: ./container/ubuntu24-cuda13/Dockerfile
           - name: RockyLinux-9/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
             dockerfile: ./container/rockylinux9-cuda12/Dockerfile
@@ -154,10 +154,10 @@ jobs:
       fail-fast: false
       matrix:
         variance:
-          - name: Ubuntu-22.04/CUDA-12.8.1
-            image: "rust-gpu/rust-cuda-ubuntu22-cuda12"
           - name: Ubuntu-24.04/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
+          - name: Ubuntu-24.04/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda13"
           - name: RockyLinux-9/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
     steps:

--- a/container/ubuntu24-cuda13/Dockerfile
+++ b/container/ubuntu24-cuda13/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS llvm-builder
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04 AS llvm-builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     build-essential \
@@ -50,7 +50,7 @@ RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmo
     cd ../.. && \
     rm -rf llvm-7.1.0.src*
 
-FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
     build-essential \


### PR DESCRIPTION
- Remove Ubuntu 22.04. 24.04 is the most recent LTS and it's 1.5 years old; we don't need 22.04 as well.
    
- Add CUDA 13.0 pairings with Ubuntu 24.04 and Windows. This requires adding an ubuntu24-cuda13 Dockerfile.
