### PR TITLE
Fix non-release kernel builds via CudaBuilder

### DIFF
--- a/crates/cuda_builder/src/lib.rs
+++ b/crates/cuda_builder/src/lib.rs
@@ -715,6 +715,12 @@ fn invoke_rustc(builder: &CudaBuilder) -> Result<PathBuf, CudaBuilderError> {
         rustflags.push(format!("--emit={string}"));
     }
 
+    if builder.debug == DebugInfo::None {
+        // Default dev builds: strip debuginfo to avoid libnvvm crashes with unoptimized IR.
+        // TODO: drop this once newer libnvvm toolchains are stable with debuginfo in opt=0 builds.
+        rustflags.push("-Cdebuginfo=0".into());
+    }
+
     let mut llvm_args = vec![NvvmOption::Arch(builder.arch).to_string()];
 
     if !builder.nvvm_opts {

--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -296,9 +296,9 @@ unsafe fn match_any_32(mask: u32, value: u32) -> u32 {
 unsafe fn match_any_64(mask: u32, value: u64) -> u32 {
     extern "C" {
         #[link_name = "llvm.nvvm.match.any.sync.i64"]
-        fn __nvvm_warp_match_any_64(mask: u32, value: u64) -> u32;
+        fn __nvvm_warp_match_any_64(mask: u32, value: u64) -> u64;
     }
-    __nvvm_warp_match_any_64(mask, value)
+    __nvvm_warp_match_any_64(mask, value) as u32
 }
 
 #[gpu_only]

--- a/crates/rustc_codegen_nvvm/src/ty.rs
+++ b/crates/rustc_codegen_nvvm/src/ty.rs
@@ -228,10 +228,16 @@ impl<'ll, 'tcx> BaseTypeCodegenMethods for CodegenCx<'ll, 'tcx> {
 
     fn float_width(&self, ty: &'ll Type) -> usize {
         match self.type_kind(ty) {
+            TypeKind::Half => 16,
             TypeKind::Float => 32,
             TypeKind::Double => 64,
             TypeKind::X86_FP80 => 80,
             TypeKind::FP128 | TypeKind::PPC_FP128 => 128,
+            TypeKind::BFloat => 16,
+            TypeKind::Vector | TypeKind::ScalableVector => {
+                // Recurse on element type for vector floats
+                self.float_width(self.element_type(ty))
+            }
             _ => bug!("llvm_float_width called on a non-float type"),
         }
     }


### PR DESCRIPTION
First, we weren't handling all the types.
After fixing that, it exposed a `libnvvm` crash.
Also saw a type issue in one of the warp APIs used by vecadd so fixed that.

Fixes https://github.com/Rust-GPU/rust-cuda/issues/320