### PR TITLE
Expand CI coverage

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -158,24 +158,24 @@ jobs:
             cargo clippy
           '
 
-      # Very limited testing because we can only run tests that don't rely on having a CUDA GPU.
+      # Exclude crates with tests that require an NVIDIA GPU: blastoff, cudnn, cust.
       - name: Test
         run: |
           docker exec "$CONTAINER_NAME" bash -lc 'set -euo pipefail
             export RUSTFLAGS=-Dwarnings
-            cargo test \
-              -p cuda_std \
-              -p gpu_rand \
-              -p nvvm \
-              -p rustc_codegen_nvvm
+            cargo test --workspace \
+              --exclude blastoff \
+              --exclude cudnn \
+              --exclude cust
           '
 
+      # Exclude cust_raw because it triggers hundreds of warnings.
       - name: Check documentation
         run: |
           docker exec "$CONTAINER_NAME" bash -lc 'set -euo pipefail
             export RUSTDOCFLAGS=-Dwarnings
             cargo doc --workspace --all-features --document-private-items --no-deps \
-              --exclude "cust_raw"
+              --exclude cust_raw
           '
 
       - name: Normalize build artifacts ownership

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -88,22 +88,29 @@ jobs:
       - name: Build all bindings
         run: cargo build --all-features -p cust_raw
 
+      # Exclude crates that require cuDNN, not available on Windows CI: cudnn, cudnn-sys.
+      # Exclude vecadd because of a link error involving nanorand and `SystemFunction036` (a.k.a.
+      # `RtlGenRandom`).
       - name: Build workspace
-        run: cargo build --workspace --exclude "cudnn*" --exclude "gemm*" --exclude "i128*" --exclude "sha2*" --exclude "vecadd*"
+        run: cargo build --workspace --exclude cudnn --exclude cudnn-sys --exclude "vecadd*"
 
+      # Exclude crates that require cuDNN, not available on Windows CI: cudnn, cudnn-sys.
       - name: Clippy
         env:
           RUSTFLAGS: -Dwarnings
-        run: cargo clippy --workspace --exclude "cudnn*" --exclude "gemm*" --exclude "i128*" --exclude "sha2*" --exclude "vecadd*"
+        run: cargo clippy --workspace --exclude cudnn --exclude cudnn-sys
 
-      # Very limited testing because we can only run tests that don't rely on having a CUDA GPU.
+      # Exclude crates with tests that require an NVIDIA GPU: blastoff, cudnn, cust.
+      # Exclude crates that require cuDNN, not available on Windows CI: cudnn, cudnn-sys.
       - name: Test
-        run: cargo test -p cuda_std -p gpu_rand -p nvvm -p rustc_codegen_nvvm
+        run: cargo test --workspace --exclude blastoff --exclude cudnn --exclude cudnn-sys --exclude cust
 
+      # Exclude crates that require cuDNN, not available on Windows CI: cudnn, cudnn-sys.
+      # Exclude cust_raw because it triggers hundreds of warnings.
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -Dwarnings
-        run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude "cudnn*" --exclude "cust_raw" --exclude "gemm*" --exclude "i128*" --exclude "sha2*" --exclude "vecadd*"
+        run: cargo doc --workspace --all-features --document-private-items --no-deps --exclude cudnn --exclude cudnn-sys --exclude cust_raw
 
       # Disabled due to dll issues, someone with Windows knowledge needed
       # - name: Compiletest


### PR DESCRIPTION
For `cargo test`, use an exclusion approach instead of an inclusion approach, to increase coverage.
    
For `cargo {build,clippy,doc}`, include the examples on Windows CI. (`cargo build` doesn't work for `vecadd` due to a `nanorand` linking problem, but everything else works.)
