### PR TITLE
Add Dockerfiles for CUDA 13.

### DIFF
--- a/.github/workflows/container_images.yml
+++ b/.github/workflows/container_images.yml
@@ -33,9 +33,15 @@ jobs:
           - name: Ubuntu-24.04/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
             dockerfile: ./container/ubuntu24-cuda12/Dockerfile
+          - name: Ubuntu-24.04/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda13"
+            dockerfile: ./container/ubuntu24-cuda13/Dockerfile
           - name: RockyLinux-9/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
             dockerfile: ./container/rockylinux9-cuda12/Dockerfile
+          - name: RockyLinux-9/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-rockylinux9-cuda13"
+            dockerfile: ./container/rockylinux9-cuda13/Dockerfile
     steps:
       - name: Free up space
         # Without this the job will likely run out of disk space.
@@ -153,8 +159,12 @@ jobs:
         variance:
           - name: Ubuntu-24.04/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-ubuntu24-cuda12"
+          - name: Ubuntu-24.04/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-ubuntu24-cuda13"
           - name: RockyLinux-9/CUDA-12.8.1
             image: "rust-gpu/rust-cuda-rockylinux9-cuda12"
+          - name: RockyLinux-9/CUDA-13.0.2
+            image: "rust-gpu/rust-cuda-rockylinux9-cuda13"
     steps:
       - name: Set artifact name
         run: |

--- a/container/rockylinux9-cuda13/Dockerfile
+++ b/container/rockylinux9-cuda13/Dockerfile
@@ -1,0 +1,92 @@
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-rockylinux9 AS llvm-builder
+
+RUN dnf -y install \
+    --nobest \
+    --allowerasing \
+    --setopt=install_weak_deps=False \
+    openssl-devel \
+    pkgconfig \
+    which \
+    xz \
+    zlib-devel \
+    libffi-devel \
+    ncurses-devel \
+    libxml2-devel \
+    libedit-devel \
+    python3 \
+    make \
+    cmake && \
+    dnf clean all
+
+WORKDIR /data/llvm7
+
+# Download and build LLVM 7.1.0 for all architectures.
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/opt/llvm-7 \
+        .. && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src* && \
+    dnf clean all
+
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-rockylinux9
+
+RUN dnf -y install \
+    --nobest \
+    --allowerasing \
+    --setopt=install_weak_deps=False \
+    clang \
+    openssl-devel \
+    fontconfig-devel \
+    libX11-devel \
+    libXcursor-devel \
+    libXi-devel \
+    libXrandr-devel \
+    libxml2-devel \
+    ncurses-devel \
+    pkgconfig \
+    which \
+    xz \
+    zlib-devel \
+    cmake && \
+    dnf clean all
+
+COPY --from=llvm-builder /opt/llvm-7 /opt/llvm-7
+RUN ln -s /opt/llvm-7/bin/llvm-config /usr/bin/llvm-config && \
+    ln -s /opt/llvm-7/bin/llvm-config /usr/bin/llvm-config-7
+
+# Get Rust (install rustup; toolchain installed from rust-toolchain.toml below)
+RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y --profile minimal --default-toolchain none
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Setup the workspace
+WORKDIR /data/rust-cuda
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/rust-cuda/rust-toolchain.toml \
+    rustup show
+
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+ENV LLVM_LINK_STATIC=1
+ENV RUST_LOG=info

--- a/container/ubuntu24-cuda13/Dockerfile
+++ b/container/ubuntu24-cuda13/Dockerfile
@@ -1,0 +1,89 @@
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04 AS llvm-builder
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    build-essential \
+    clang \
+    curl \
+    libffi-dev \
+    libedit-dev \
+    libncurses5-dev \
+    libssl-dev \
+    libtinfo-dev \
+    libxml2-dev \
+    cmake \
+    ninja-build \
+    pkg-config \
+    python3 \
+    xz-utils \
+    zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /data/llvm7
+
+# Download and build LLVM 7.1.0 for all architectures.
+RUN curl -sSf -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-7.1.0/llvm-7.1.0.src.tar.xz && \
+    tar -xf llvm-7.1.0.src.tar.xz && \
+    cd llvm-7.1.0.src && \
+    mkdir build && cd build && \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        TARGETS="X86;NVPTX"; \
+    else \
+        TARGETS="AArch64;NVPTX"; \
+    fi && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_TARGETS_TO_BUILD="$TARGETS" \
+        -DLLVM_BUILD_LLVM_DYLIB=ON \
+        -DLLVM_LINK_LLVM_DYLIB=ON \
+        -DLLVM_ENABLE_ASSERTIONS=OFF \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_ENABLE_ZLIB=ON \
+        -DLLVM_ENABLE_TERMINFO=ON \
+        -DCMAKE_INSTALL_PREFIX=/opt/llvm-7 \
+        .. && \
+    ninja -j$(nproc) && \
+    ninja install && \
+    cd ../.. && \
+    rm -rf llvm-7.1.0.src*
+
+FROM nvcr.io/nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    build-essential \
+    clang \
+    curl \
+    libssl-dev \
+    libtinfo-dev \
+    pkg-config \
+    xz-utils \
+    zlib1g-dev \
+    cmake \
+    libfontconfig-dev \
+    libx11-xcb-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libxinerama-dev \
+    libxrandr-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=llvm-builder /opt/llvm-7 /opt/llvm-7
+RUN ln -s /opt/llvm-7/bin/llvm-config /usr/bin/llvm-config && \
+    ln -s /opt/llvm-7/bin/llvm-config /usr/bin/llvm-config-7
+
+# Get Rust (install rustup; toolchain installed from rust-toolchain.toml below)
+RUN curl -sSf -L https://sh.rustup.rs | bash -s -- -y --profile minimal --default-toolchain none
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Setup the workspace
+WORKDIR /data/rust-cuda
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/data/rust-cuda/rust-toolchain.toml \
+    rustup show
+
+# Add nvvm to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/nvvm/lib64:${LD_LIBRARY_PATH}"
+ENV LLVM_LINK_STATIC=1
+ENV RUST_LOG=info


### PR DESCRIPTION
For both Ubuntu 24.04 and RockyLinux 9. Both files are just copies of the respective CUDA 12 Dockerfiles with `12.8.1` changed to `13.0.2`.

Also include them in the container image jobs on CI.