### PR TITLE
Test CUDA 13.0 on Linux CI.

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -28,8 +28,17 @@ jobs:
           - name: Ubuntu-24.04 / CUDA-12.8.1 / ARM64
             image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12:latest"
             runner: ubuntu-24.04-arm
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / x86_64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
+            runner: ubuntu-latest
+          - name: Ubuntu-24.04 / CUDA-13.0.2 / ARM64
+            image: "ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda13:latest"
+            runner: ubuntu-24.04-arm
           - name: RockyLinux-9 / CUDA-12.8.1 / x86_64
             image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda12:latest"
+            runner: ubuntu-latest
+          - name: RockyLinux-9 / CUDA-13.0.2 / x86_64
+            image: "ghcr.io/rust-gpu/rust-cuda-rockylinux9-cuda13:latest"
             runner: ubuntu-latest
 
     steps:

--- a/crates/cudnn-sys/build/cudnn_sdk.rs
+++ b/crates/cudnn-sys/build/cudnn_sdk.rs
@@ -62,7 +62,15 @@ impl CudnnSdk {
         let cudnn_include_dir = env::var_os("CUDNN_INCLUDE_DIR");
 
         #[cfg(not(target_os = "windows"))]
-        const CUDNN_DEFAULT_PATHS: &[&str] = &["/usr/include", "/usr/local/include"];
+        const CUDNN_DEFAULT_PATHS: &[&str] = &[
+            "/usr/include",
+            "/usr/local/include",
+            // CUDA 13 seems to have moved the headers into arch-specific directories.
+            "/usr/include/x86_64-linux-gnu",
+            "/usr/include/aarch64-linux-gnu",
+            "/usr/local/include/x86_64-linux-gnu",
+            "/usr/local/include/aarch64-linux-gnu",
+        ];
         #[cfg(target_os = "windows")]
         const CUDNN_DEFAULT_PATHS: &[&str] = &[
             "C:/Program Files/NVIDIA/CUDNN/v9.x/include",


### PR DESCRIPTION
The CUDA 13.0 Dockerfiles were added in #328.