### PR TITLE
Fix `path-tracer`.

### DIFF
--- a/crates/optix/examples/path_tracer/kernels/src/material.rs
+++ b/crates/optix/examples/path_tracer/kernels/src/material.rs
@@ -1,4 +1,4 @@
-use crate::{hittable::HitRecord, math::*, Ray, Vec3};
+use crate::{Ray, Vec3, hittable::HitRecord, math::*};
 use approx::{AbsDiffEq, RelativeEq};
 use cust_core::DeviceCopy;
 use enum_dispatch::enum_dispatch;
@@ -90,16 +90,16 @@ impl Material for DielectricMaterial {
             cos = -incoming.dir.dot(hit.normal) / incoming.dir.length();
         }
 
-        if let Some(refracted) = refract(incoming.dir, outward_norm, ni_over_nt) {
-            if rng.normal_f32() > schlick(cos, self.ior) {
-                return (
-                    self.color,
-                    Some(Ray {
-                        origin: hit.point,
-                        dir: refracted,
-                    }),
-                );
-            }
+        if let Some(refracted) = refract(incoming.dir, outward_norm, ni_over_nt)
+            && rng.normal_f32() > schlick(cos, self.ior)
+        {
+            return (
+                self.color,
+                Some(Ray {
+                    origin: hit.point,
+                    dir: refracted,
+                }),
+            );
         }
 
         (

--- a/crates/optix/examples/path_tracer/kernels/src/render_kernels.rs
+++ b/crates/optix/examples/path_tracer/kernels/src/render_kernels.rs
@@ -12,13 +12,15 @@ pub unsafe fn render(fb: *mut Vec3, view: Viewport, scene: &Scene, rand_states: 
     let px_idx = idx.y as usize * view.bounds.x + idx.x as usize;
 
     // generate a tiny offset for the ray for antialiasing
-    let rng = &mut *rand_states.add(px_idx);
+    let rng = unsafe { &mut *rand_states.add(px_idx) };
     let offset = Vec2::from(rng.normal_f32_2());
 
     let ray = generate_ray(idx, &view, offset);
 
     let color = scene.ray_color(ray, rng);
-    *fb.add(px_idx) += color;
+    unsafe {
+        *fb.add(px_idx) += color;
+    }
 }
 
 /// Scales an accumulated buffer by the sample count, storing each pixel in the corresponding `out` pixel.
@@ -29,8 +31,8 @@ pub unsafe fn scale_buffer(fb: *const Vec3, out: *mut Vec3, samples: u32, view: 
         return;
     }
     let idx = idx_2d.y as usize * view.bounds.x + idx_2d.x as usize;
-    let original = &*fb.add(idx);
-    let out = &mut *out.add(idx);
+    let original = unsafe { &*fb.add(idx) };
+    let out = unsafe { &mut *out.add(idx) };
 
     let scale = 1.0 / samples as f32;
     let scaled = original * scale;
@@ -45,8 +47,8 @@ pub unsafe fn postprocess(fb: *const Vec3, out: *mut U8Vec3, view: Viewport) {
         return;
     }
     let idx = idx_2d.y as usize * view.bounds.x + idx_2d.x as usize;
-    let original = &*fb.add(idx);
-    let out = &mut *out.add(idx);
+    let original = unsafe { &*fb.add(idx) };
+    let out = unsafe { &mut *out.add(idx) };
     // gamma=2.0
     let gamma_corrected = original.map(f32::sqrt);
 

--- a/crates/optix/examples/path_tracer/src/cpu/mod.rs
+++ b/crates/optix/examples/path_tracer/src/cpu/mod.rs
@@ -4,7 +4,7 @@ use glam::{U8Vec3, USizeVec2, UVec2, Vec2, Vec3};
 use gpu_rand::{DefaultRand, GpuRand};
 use imgui::Ui;
 use path_tracer_kernels::{
-    material::MaterialKind, render::generate_ray, scene::Scene, Object, Viewport,
+    Object, Viewport, material::MaterialKind, render::generate_ray, scene::Scene,
 };
 use rayon::prelude::*;
 use sysinfo::System;

--- a/crates/optix/examples/path_tracer/src/cuda/data.rs
+++ b/crates/optix/examples/path_tracer/src/cuda/data.rs
@@ -7,7 +7,7 @@ use cust::{
 };
 use glam::{U8Vec3, USizeVec2, Vec3};
 use gpu_rand::DefaultRand;
-use path_tracer_kernels::{material::MaterialKind, scene::Scene, Object, Viewport};
+use path_tracer_kernels::{Object, Viewport, material::MaterialKind, scene::Scene};
 
 use super::SEED;
 

--- a/crates/optix/examples/path_tracer/src/main.rs
+++ b/crates/optix/examples/path_tracer/src/main.rs
@@ -9,10 +9,10 @@ pub mod viewer;
 use common::Camera;
 use glam::Vec3;
 use path_tracer_kernels::{
+    Object,
     material::{DielectricMaterial, DiffuseMaterial, MaterialKind, MetallicMaterial},
     scene::Scene,
     sphere::Sphere,
-    Object,
 };
 use std::error::Error;
 

--- a/crates/optix/examples/path_tracer/src/viewer.rs
+++ b/crates/optix/examples/path_tracer/src/viewer.rs
@@ -1,16 +1,17 @@
 use glam::USizeVec2;
 use glium::{
+    Display, Program, Rect, Surface, VertexBuffer,
     glutin::{
+        ContextBuilder,
         dpi::PhysicalSize,
         event::{Event, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
         window::WindowBuilder,
-        ContextBuilder,
     },
     implement_vertex,
     index::{NoIndices, PrimitiveType},
     texture::{RawImage2d, SrgbTexture2d},
-    uniform, Display, Program, Rect, Surface, VertexBuffer,
+    uniform,
 };
 
 use imgui::Condition;
@@ -18,7 +19,7 @@ use imgui_winit_support::{HiDpiMode, WinitPlatform};
 use path_tracer_kernels::scene::Scene;
 use std::time::Instant;
 
-use crate::{common::Camera, renderer::Renderer, HEIGHT, WIDTH};
+use crate::{HEIGHT, WIDTH, common::Camera, renderer::Renderer};
 
 static IMAGE_VERT: &str = include_str!("../shaders/image.vert");
 static IMAGE_FRAG: &str = include_str!("../shaders/image.frag");


### PR DESCRIPTION
The merging of two unintentionally interdependent PRs left `path-tracer` in a broken state.
- #335 updated it from edition 2018 to 2024, while it was disabled (commented out).
- #332 re-enabled it.

This left it marked as using edition 2024 but without the appropriate changes for edition 2024. This commit makes those changes.