### PR TITLE
fix(cuda_std): use correct PTX scope suffix in atomic load/store

### DIFF
--- a/crates/cuda_std/src/atomic/intrinsics.rs
+++ b/crates/cuda_std/src/atomic/intrinsics.rs
@@ -52,11 +52,11 @@ pub unsafe fn fence_acqrel_system() {
 
 #[allow(unused_macros)]
 macro_rules! load_scope {
-    (volatile, $scope:ident) => {
+    (volatile, $scope_asm:ident) => {
         ""
     };
-    ($ordering:ident, $scope:ident) => {
-        concat!(".", stringify!($scope))
+    ($ordering:ident, $scope_asm:ident) => {
+        concat!(".", stringify!($scope_asm))
     };
 }
 
@@ -70,7 +70,7 @@ macro_rules! load {
                 pub unsafe fn [<atomic_load_ $ordering _ $width _ $scope>](ptr: *const [<u $width>]) -> [<u $width>] {
                     let mut out;
                     asm!(
-                        concat!("ld.", stringify!($ordering), load_scope!($ordering, $scope), ".", stringify!([<u $width>]), " {}, [{}];"),
+                        concat!("ld.", stringify!($ordering), load_scope!($ordering, $scope_asm), ".", stringify!([<u $width>]), " {}, [{}];"),
                         out([<reg $width>]) out,
                         in(reg64) ptr
                     );
@@ -116,7 +116,7 @@ macro_rules! store {
                 #[doc = concat!("Performs a ", stringify!($ordering), " atomic store at the ", stringify!($scope), " level with a width of ", stringify!($width), " bits")]
                 pub unsafe fn [<atomic_store_ $ordering _ $width _ $scope>](ptr: *mut [<u $width>], val: [<u $width>]) {
                     asm!(
-                        concat!("st.", stringify!($ordering), load_scope!($ordering, $scope), ".", stringify!([<u $width>]), " [{}], {};"),
+                        concat!("st.", stringify!($ordering), load_scope!($ordering, $scope_asm), ".", stringify!([<u $width>]), " [{}], {};"),
                         in(reg64) ptr,
                         in([<reg $width>]) val,
                     );


### PR DESCRIPTION
This PR fixes a bug in the `load_scope!` macro in `crates/cuda_std/src/atomic/intrinsics.rs`

Previously, the macro was using the $scope identifier (e.g., device, block) when generating the PTX instruction string. This resulted in invalid assembly instructions like `ld.relaxed.device.u32`.

This change updates the macro to use `$scope_asm` (e.g., gpu, cta), ensuring valid PTX suffixes are generated (e.g., `ld.relaxed.gpu.u32`).

fixes #354 