### PR TITLE
fix(cuda_std): align WarpShuffleMode discriminants with LLVM intrinsics

### DIFF
--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -735,10 +735,10 @@ impl WarpShuffleValue for bf16 {
 #[repr(u32)]
 #[derive(Clone, Copy)]
 pub enum WarpShuffleMode {
-    Up,
-    Down,
-    Idx,
-    Xor,
+    Idx = 0,
+    Up = 1,
+    Down = 2,
+    Xor = 3,
 }
 
 // C-compatible struct to match LLVM IR's {i32, i8} return type


### PR DESCRIPTION
The `WarpShuffleMode` enum previously relied on implicit discriminants (Up=0, Down=1, Idx=2, Xor=3), which misaligned with the integer values expected by the `llvm.nvvm.shfl.sync.i32` intrinsic (Idx=0, Up=1, Down=2, Bfly=3).

Fixes #359 
