### PR TITLE
fix(cudnn): implement cuDNN 9 error codes, replace todo!() panic with proper mapping

### DIFF
--- a/crates/cudnn/src/error.rs
+++ b/crates/cudnn/src/error.rs
@@ -174,3 +174,175 @@ impl IntoResult for cudnn_sys::cudnnStatus_t {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_maps_to_ok() {
+        use cudnn_sys::cudnnStatus_t::*;
+        assert!(CUDNN_STATUS_SUCCESS.into_result().is_ok());
+    }
+
+    #[test]
+    fn common_status_codes_map() {
+        use cudnn_sys::cudnnStatus_t::*;
+        assert_eq!(
+            CUDNN_STATUS_NOT_INITIALIZED.into_result().unwrap_err(),
+            CudnnError::NotInitialized
+        );
+        assert_eq!(
+            CUDNN_STATUS_BAD_PARAM.into_result().unwrap_err(),
+            CudnnError::BadParam
+        );
+        assert_eq!(
+            CUDNN_STATUS_INTERNAL_ERROR.into_result().unwrap_err(),
+            CudnnError::InternalError
+        );
+        assert_eq!(
+            CUDNN_STATUS_INVALID_VALUE.into_result().unwrap_err(),
+            CudnnError::InvalidValue
+        );
+        assert_eq!(
+            CUDNN_STATUS_EXECUTION_FAILED.into_result().unwrap_err(),
+            CudnnError::ExecutionFailed
+        );
+        assert_eq!(
+            CUDNN_STATUS_NOT_SUPPORTED.into_result().unwrap_err(),
+            CudnnError::NotSupported
+        );
+        assert_eq!(
+            CUDNN_STATUS_LICENSE_ERROR.into_result().unwrap_err(),
+            CudnnError::LicenseError
+        );
+        assert_eq!(
+            CUDNN_STATUS_RUNTIME_IN_PROGRESS.into_result().unwrap_err(),
+            CudnnError::RuntimeInProgress
+        );
+        assert_eq!(
+            CUDNN_STATUS_RUNTIME_FP_OVERFLOW.into_result().unwrap_err(),
+            CudnnError::RuntimeFpOverflow
+        );
+    }
+
+    #[cfg(not(cudnn9))]
+    #[test]
+    fn cudnn8_only_status_codes_map() {
+        use cudnn_sys::cudnnStatus_t::*;
+        assert_eq!(
+            CUDNN_STATUS_ALLOC_FAILED.into_result().unwrap_err(),
+            CudnnError::AllocFailed
+        );
+        assert_eq!(
+            CUDNN_STATUS_ARCH_MISMATCH.into_result().unwrap_err(),
+            CudnnError::ArchMismatch
+        );
+        assert_eq!(
+            CUDNN_STATUS_MAPPING_ERROR.into_result().unwrap_err(),
+            CudnnError::MappingError
+        );
+        assert_eq!(
+            CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING
+                .into_result()
+                .unwrap_err(),
+            CudnnError::RuntimePrerequisiteMissing
+        );
+        assert_eq!(
+            CUDNN_STATUS_VERSION_MISMATCH.into_result().unwrap_err(),
+            CudnnError::VersionMismatch
+        );
+    }
+
+    #[cfg(cudnn9)]
+    #[test]
+    fn cudnn9_named_status_codes_map() {
+        use cudnn_sys::cudnnStatus_t::*;
+        assert_eq!(
+            CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH
+                .into_result()
+                .unwrap_err(),
+            CudnnError::SublibraryVersionMismatch
+        );
+        assert_eq!(
+            CUDNN_STATUS_SERIALIZATION_VERSION_MISMATCH
+                .into_result()
+                .unwrap_err(),
+            CudnnError::SerializationVersionMismatch
+        );
+        assert_eq!(
+            CUDNN_STATUS_DEPRECATED.into_result().unwrap_err(),
+            CudnnError::Deprecated
+        );
+        assert_eq!(
+            CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED
+                .into_result()
+                .unwrap_err(),
+            CudnnError::SublibraryLoadingFailed
+        );
+    }
+
+    /// cuDNN 9 hierarchical sub-codes (2xxx/3xxx/…) must map to the parent category, not panic.
+    #[cfg(cudnn9)]
+    #[test]
+    fn cudnn9_hierarchical_subcodes_map_to_parent_category() {
+        use cudnn_sys::cudnnStatus_t::*;
+        assert_eq!(
+            CUDNN_STATUS_BAD_PARAM_NULL_POINTER
+                .into_result()
+                .unwrap_err(),
+            CudnnError::BadParam
+        );
+        assert_eq!(
+            CUDNN_STATUS_NOT_SUPPORTED_SHAPE.into_result().unwrap_err(),
+            CudnnError::NotSupported
+        );
+    }
+
+    #[cfg(cudnn9)]
+    #[test]
+    fn cudnn9_into_raw_round_trips_for_named_errors() {
+        let cases = [
+            CudnnError::SublibraryVersionMismatch,
+            CudnnError::SerializationVersionMismatch,
+            CudnnError::Deprecated,
+            CudnnError::SublibraryLoadingFailed,
+        ];
+        for err in cases {
+            assert_eq!(err.into_raw().into_result().unwrap_err(), err);
+        }
+    }
+
+    #[test]
+    fn into_raw_round_trips_for_common_errors() {
+        let cases = [
+            CudnnError::NotInitialized,
+            CudnnError::BadParam,
+            CudnnError::InternalError,
+            CudnnError::InvalidValue,
+            CudnnError::ExecutionFailed,
+            CudnnError::NotSupported,
+            CudnnError::LicenseError,
+            CudnnError::RuntimeInProgress,
+            CudnnError::RuntimeFpOverflow,
+        ];
+        for err in cases {
+            assert_eq!(err.into_raw().into_result().unwrap_err(), err);
+        }
+    }
+
+    #[cfg(not(cudnn9))]
+    #[test]
+    fn into_raw_round_trips_for_cudnn8_only_errors() {
+        let cases = [
+            CudnnError::AllocFailed,
+            CudnnError::ArchMismatch,
+            CudnnError::MappingError,
+            CudnnError::RuntimePrerequisiteMissing,
+            CudnnError::VersionMismatch,
+        ];
+        for err in cases {
+            assert_eq!(err.into_raw().into_result().unwrap_err(), err);
+        }
+    }
+}

--- a/crates/cudnn/src/error.rs
+++ b/crates/cudnn/src/error.rs
@@ -52,6 +52,18 @@ pub enum CudnnError {
     RuntimeFpOverflow,
     #[cfg(not(cudnn9))]
     VersionMismatch,
+    /// A version mismatch was detected between cuDNN sub-libraries (cuDNN 9+).
+    #[cfg(cudnn9)]
+    SublibraryVersionMismatch,
+    /// A serialization version mismatch was detected (cuDNN 9+).
+    #[cfg(cudnn9)]
+    SerializationVersionMismatch,
+    /// A deprecated API was called (cuDNN 9+).
+    #[cfg(cudnn9)]
+    Deprecated,
+    /// A required sub-library could not be loaded (cuDNN 9+).
+    #[cfg(cudnn9)]
+    SublibraryLoadingFailed,
 }
 
 impl CudnnError {
@@ -78,6 +90,14 @@ impl CudnnError {
             CudnnError::RuntimeFpOverflow => CUDNN_STATUS_RUNTIME_FP_OVERFLOW,
             #[cfg(not(cudnn9))]
             CudnnError::VersionMismatch => CUDNN_STATUS_VERSION_MISMATCH,
+            #[cfg(cudnn9)]
+            CudnnError::SublibraryVersionMismatch => CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH,
+            #[cfg(cudnn9)]
+            CudnnError::SerializationVersionMismatch => CUDNN_STATUS_SERIALIZATION_VERSION_MISMATCH,
+            #[cfg(cudnn9)]
+            CudnnError::Deprecated => CUDNN_STATUS_DEPRECATED,
+            #[cfg(cudnn9)]
+            CudnnError::SublibraryLoadingFailed => CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED,
         }
     }
 }
@@ -124,8 +144,33 @@ impl IntoResult for cudnn_sys::cudnnStatus_t {
             CUDNN_STATUS_RUNTIME_FP_OVERFLOW => CudnnError::RuntimeFpOverflow,
             #[cfg(not(cudnn9))]
             CUDNN_STATUS_VERSION_MISMATCH => CudnnError::VersionMismatch,
-            // TODO(adamcavendish): implement cuDNN 9 error codes.
-            _ => todo!(),
+            // cuDNN 9 introduced a hierarchical status code system. Specific sub-codes
+            // (e.g. CUDNN_STATUS_BAD_PARAM_NULL_POINTER = 2002) are mapped to their
+            // parent category variant for backwards-compatible error handling.
+            #[cfg(cudnn9)]
+            CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH => CudnnError::SublibraryVersionMismatch,
+            #[cfg(cudnn9)]
+            CUDNN_STATUS_SERIALIZATION_VERSION_MISMATCH => CudnnError::SerializationVersionMismatch,
+            #[cfg(cudnn9)]
+            CUDNN_STATUS_DEPRECATED => CudnnError::Deprecated,
+            #[cfg(cudnn9)]
+            CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED => CudnnError::SublibraryLoadingFailed,
+            #[cfg(cudnn9)]
+            s => {
+                use cudnn_sys::cudnnStatus_t::*;
+                // Map cuDNN 9 hierarchical sub-codes to their parent category variant.
+                // Sub-codes share the same thousands digit as their parent:
+                //   2xxx -> BAD_PARAM, 3xxx -> NOT_SUPPORTED,
+                //   4xxx -> INTERNAL_ERROR, 5xxx -> EXECUTION_FAILED
+                let category = (s as u32) / 1000 * 1000;
+                match category {
+                    c if c == CUDNN_STATUS_BAD_PARAM as u32 => CudnnError::BadParam,
+                    c if c == CUDNN_STATUS_NOT_SUPPORTED as u32 => CudnnError::NotSupported,
+                    c if c == CUDNN_STATUS_INTERNAL_ERROR as u32 => CudnnError::InternalError,
+                    c if c == CUDNN_STATUS_EXECUTION_FAILED as u32 => CudnnError::ExecutionFailed,
+                    _ => CudnnError::InternalError,
+                }
+            }
         })
     }
 }


### PR DESCRIPTION
## Summary

Fixes a **runtime process panic** in `crates/cudnn/src/error.rs` that occurs when the crate is compiled against **cuDNN 9+**. The wildcard arm `_ => todo!()` in `IntoResult::into_result()` would abort the process whenever cuDNN returned any of the new hierarchical sub-codes introduced in cuDNN 9. This PR replaces it with a proper category-based fallback mapping.

---

## Problem

### Background: how cuDNN version detection works

At **compile time**, the build script reads the cuDNN version from the linker metadata and emits a `cfg` flag:

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  crates/cudnn/build.rs                                                      │
│                                                                             │
│  DEP_CUDNN_VERSION ──► parse as u32 ──► >= 90000?                          │
│                                                 │                           │
│                                        ┌────────┴────────┐                 │
│                                       YES               NO                 │
│                                        │                 │                 │
│                                        ▼                 ▼                 │
│                             cargo::rustc-cfg=cudnn9   (nothing)            │
└─────────────────────────────────────────────────────────────────────────────┘
                    │
                    ▼
        Source files compiled with #[cfg(cudnn9)]
        or #[cfg(not(cudnn9))] blocks selected accordingly
```

That part works fine. The bug lives entirely in the **runtime** code that the cfg selection activates.

### The broken runtime path (before this PR)

cuDNN 9 restructured `cudnnStatus_t` into a **hierarchical numeric system**. Each broad error category was split into specific sub-codes that share the same thousands-digit as their parent:

```
  Category numeric prefix   Examples (cuDNN 9 new sub-codes)
  ═══════════════════════╦═══════════════════════════════════════════════════
  2xxx  BAD_PARAM        ║  2002 CUDNN_STATUS_BAD_PARAM_NULL_POINTER
  3xxx  NOT_SUPPORTED    ║  3007 CUDNN_STATUS_NOT_SUPPORTED_ARCH_MISMATCH
  4xxx  INTERNAL_ERROR   ║  4001 CUDNN_STATUS_INTERNAL_ERROR_ASSERTION_FAILED
  5xxx  EXECUTION_FAILED ║  5001 CUDNN_STATUS_EXECUTION_FAILED_INSUFFICIENT_MEM
```

The old `into_result()` only matched the **parent** codes exactly. Any unrecognised sub-code fell into the wildcard arm:

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  IntoResult::into_result()  — BEFORE (cfg(cudnn9) build)                   │
│                                                                             │
│  cudnnStatus_t raw value                                                    │
│       │                                                                     │
│       ▼                                                                     │
│  CUDNN_STATUS_SUCCESS ──────────────────────────────────► Ok(())            │
│       │                                                                     │
│  known exact variants (NOT_INITIALIZED, BAD_PARAM …) ──► Err(CudnnError…)  │
│       │                                                                     │
│  _ => todo!()  ◄──── cuDNN 9 sub-codes land HERE                           │
│       │                                                                     │
│       └──────────────────────────────────────────────► 💥 PROCESS PANIC    │
└─────────────────────────────────────────────────────────────────────────────┘
```

---

## Fix

### Runtime path after this PR

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  IntoResult::into_result()  — AFTER (cfg(cudnn9) build)                    │
│                                                                             │
│  cudnnStatus_t raw value                                                    │
│       │                                                                     │
│       ├─► CUDNN_STATUS_SUCCESS ────────────────────────► Ok(())             │
│       │                                                                     │
│       ├─► Exact cuDNN 8 parent codes ──────────────────► Err(CudnnError…)  │
│       │   (NOT_INITIALIZED, BAD_PARAM, NOT_SUPPORTED …)                    │
│       │                                                                     │
│       ├─► New cuDNN 9 named codes ─────────────────────► Err(CudnnError…)  │
│       │   (SUBLIBRARY_VERSION_MISMATCH, DEPRECATED …)                      │
│       │                                                                     │
│       └─► Unknown cuDNN 9 sub-code  (was: todo!() 💥)                      │
│               │                                                             │
│               ▼                                                             │
│         category = raw_value / 1000 * 1000                                 │
│               │                                                             │
│         ┌─────┴──────────────────────────────────────┐                     │
│         │  2000 ──► CudnnError::BadParam              │                    │
│         │  3000 ──► CudnnError::NotSupported          │                    │
│         │  4000 ──► CudnnError::InternalError         │                    │
│         │  5000 ──► CudnnError::ExecutionFailed       │                    │
│         │  other ─► CudnnError::InternalError         │                    │
│         └────────────────────────────────────────────┘                     │
│               │                                                             │
│               └──────────────────────────────────────► Err(CudnnError…)   │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Round-trip correctness (`CudnnError ↔ cudnnStatus_t`)

`into_raw()` is also updated so the new variants can be converted back to their raw status codes, keeping `into_raw(into_result(x)) == x` for the new named variants:

```
  ┌──────────────────────┐    into_raw()   ┌───────────────────────────────┐
  │  CudnnError (Rust)   │ ──────────────► │  cudnnStatus_t (C / FFI)      │
  │                      │                 │                               │
  │  SublibraryVersion…  │ ◄────────────── │  SUBLIBRARY_VERSION_MISMATCH  │
  │  Serialization…      │   into_result() │  SERIALIZATION_VERSION…       │
  │  Deprecated          │                 │  DEPRECATED                   │
  │  SublibraryLoading…  │                 │  SUBLIBRARY_LOADING_FAILED    │
  └──────────────────────┘                 └───────────────────────────────┘
```

---

## Changes

| File | What changed |
|---|---|
| `crates/cudnn/src/error.rs` | Add 4 new `CudnnError` variants behind `#[cfg(cudnn9)]`; replace `_ => todo!()` with category-based fallback; wire variants in `into_raw()`; add unit tests |

**New `CudnnError` variants (cuDNN 9 only):**
- `SublibraryVersionMismatch` — sub-library version mismatch
- `SerializationVersionMismatch` — serialisation version mismatch
- `Deprecated` — deprecated API called
- `SublibraryLoadingFailed` — required sub-library could not be loaded

**Removed:**
- `_ => todo!()` wildcard panic — replaced with deterministic integer-division fallback

**New unit tests:**

Unit tests in `crates/cudnn/src/error.rs` — no GPU needed, run with `cargo test -p cudnn`:

| Test | Aspect covered |
|---|---|
| `success_maps_to_ok` | `CUDNN_STATUS_SUCCESS` → `Ok(())` |
| `common_status_codes_map` | All version-agnostic parent codes → correct `CudnnError` variant |
| `cudnn8_only_status_codes_map` | cuDNN 8-only codes (`AllocFailed`, `ArchMismatch`, …) gated behind `#[cfg(not(cudnn9))]` |
| `cudnn9_named_status_codes_map` | Four new cuDNN 9 named codes → correct new variants |
| `cudnn9_hierarchical_subcodes_map_to_parent_category` | **The core bug path** — sub-codes like `BAD_PARAM_NULL_POINTER` (2002) and `NOT_SUPPORTED_SHAPE` (3xxx) map to their parent category instead of panicking |
| `cudnn9_into_raw_round_trips_for_named_errors` | `CudnnError → into_raw() → into_result()` round-trip for cuDNN 9 variants |
| `into_raw_round_trips_for_common_errors` | Same round-trip for version-agnostic variants |
| `into_raw_round_trips_for_cudnn8_only_errors` | Same round-trip for cuDNN 8-only variants |

> cuDNN 9 tests compile only when `DEP_CUDNN_VERSION >= 90000`. On cuDNN 8 builds, `#[cfg(cudnn9)]` skips them.  

Run tests with `cargo test -p cudnn -- --nocapture`

---

## Verification

- Verified against `cudnn_graph.h` from **cuDNN 9.20** (CUDA 13.2, Anaconda distribution on Windows 11)
- The `cudnn` crate compiles cleanly in this configuration

## Testing

- [x] `cudnn` crate compiles with cuDNN 9.20 on Windows 11 / CUDA 13.2
- [x] No `todo!()` remains in the `#[cfg(cudnn9)]` error-handling path
- [x] All cuDNN 8 code paths preserved under `#[cfg(not(cudnn9))]`
- [x] New named variants are wired in `into_raw()` for round-trip correctness