### PR TITLE
fix(cuda_std): use correct PTX scope suffix in block acqrel fence

### DIFF
--- a/crates/cuda_std/src/atomic/intrinsics.rs
+++ b/crates/cuda_std/src/atomic/intrinsics.rs
@@ -42,7 +42,7 @@ pub unsafe fn fence_acqrel_device() {
 
 #[gpu_only]
 pub unsafe fn fence_acqrel_block() {
-    asm!("fence.acq_rel.sys;");
+    asm!("fence.acq_rel.cta;");
 }
 
 #[gpu_only]


### PR DESCRIPTION
## Summary

This updates the inline assembly to use the correct `.cta` (cooperative thread array) scope suffix, ensuring that block-level fences don't incur the unnecessary performance overhead of a system-wide synchronization.

Closes #376

## Changes

- `crates/cuda_std/src/atomic/intrinsics.rs`

## Testing

- [x] `cargo build` passes
- [x] `cargo clippy --workspace` passes
- [x] Tested on: Ubuntu 24.04.1 LTS, NVIDIA GeForce RTX 5060 Ti, CUDA 12.8.93

