### PR TITLE
SystemAtomic scope should be system not device

### DIFF
--- a/crates/cuda_std/src/atomic.rs
+++ b/crates/cuda_std/src/atomic.rs
@@ -252,5 +252,5 @@ atomic_float!(f32, AtomicF32, 4, device, 32);
 atomic_float!(f64, AtomicF64, 8, device, 64);
 atomic_float!(f32, BlockAtomicF32, 4, block, 32, unsafe);
 atomic_float!(f64, BlockAtomicF64, 8, block, 64, unsafe);
-atomic_float!(f32, SystemAtomicF32, 4, device, 32);
-atomic_float!(f64, SystemAtomicF64, 8, device, 64);
+atomic_float!(f32, SystemAtomicF32, 4, system, 32);
+atomic_float!(f64, SystemAtomicF64, 8, system, 64);


### PR DESCRIPTION


SystemAtomic scope should be system or the opcode will have the wrong scope


- [x] `cargo build` passes
- [ ] `cargo clippy --workspace` passes
- [ ] Tested on: [OS, GPU, CUDA version]

## Notes

Any additional context for reviewers.
