### PR TITLE
fix warp assert on pow of 2

### DIFF
--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -766,7 +766,7 @@ unsafe fn warp_shuffle_32(
     }
 
     assert!(
-        !(width & (width - 1)) != 0 && width <= 32,
+        width != 0 && (width & (width - 1)) == 0 && width <= 32,
         "width must be a power of 2 and less than or equal to 32"
     );
 

--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -766,7 +766,7 @@ unsafe fn warp_shuffle_32(
     }
 
     assert!(
-        width != 0 && (width & (width - 1)) == 0 && width <= 32,
+        width.is_power_of_two() && width <= 32,
         "width must be a power of 2 and less than or equal to 32"
     );
 


### PR DESCRIPTION
## Summary
Rust `!` on integers is `bitwise NOT`, `not logical NOT`, now it should assert correctly on none pow of 2 

- [x] `cargo build` passes
- [ ] `cargo clippy --workspace` passes
- [ ] Tested on: [OS, GPU, CUDA version]

## Notes

Any additional context for reviewers.
