### PR TITLE
mark warp_shuffle_64/128/16/8 as gpu_only

### DIFF
--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -779,6 +779,7 @@ unsafe fn warp_shuffle_32(
     (result.value, result.predicate != 0)
 }
 
+#[gpu_only]
 unsafe fn warp_shuffle_128(
     mode: WarpShuffleMode,
     mask: u32,
@@ -798,6 +799,7 @@ unsafe fn warp_shuffle_128(
     )
 }
 
+#[gpu_only]
 unsafe fn warp_shuffle_64(
     mode: WarpShuffleMode,
     mask: u32,
@@ -816,6 +818,7 @@ unsafe fn warp_shuffle_64(
     )
 }
 
+#[gpu_only]
 unsafe fn warp_shuffle_16(
     mode: WarpShuffleMode,
     mask: u32,
@@ -827,6 +830,7 @@ unsafe fn warp_shuffle_16(
     ((value as u16), oob)
 }
 
+#[gpu_only]
 unsafe fn warp_shuffle_8(
     mode: WarpShuffleMode,
     mask: u32,


### PR DESCRIPTION
They all contain unsafe `{ warp_shuffle_32(...) }` which uses GPU-only inline asm

- ...
- ...

## Testing

- [x] `cargo build` passes
- [ ] `cargo clippy --workspace` passes
- [ ] Tested on: [OS, GPU, CUDA version]

## Notes

Any additional context for reviewers.
