### PR TITLE
 fix(nvvm): resolve Windows CI build failures

### DIFF
--- a/crates/rustc_codegen_nvvm/build.rs
+++ b/crates/rustc_codegen_nvvm/build.rs
@@ -11,7 +11,7 @@ use tar::Archive;
 use xz::read::XzDecoder;
 
 static PREBUILT_LLVM_URL_LLVM7: &str =
-    "https://github.com/rust-gpu/rustc_codegen_nvvm-llvm/releases/download/LLVM-7.1.0/";
+    "https://github.com/rust-gpu/rustc_codegen_nvvm-llvm/releases/download/llvm-7.1.0/";
 
 fn main() {
     rustc_llvm_build(llvm19_enabled());
@@ -181,6 +181,13 @@ fn find_llvm_config_llvm7(target: &str) -> PathBuf {
             .expect("Failed to download prebuilt LLVM");
     }
 
+    let response_code = easy.response_code().unwrap();
+    if response_code != 200 {
+        fail(&format!(
+            "Failed to download prebuilt LLVM from {url}. HTTP response code: {response_code}"
+        ));
+    }
+
     let decompressor = XzDecoder::new(xz_encoded.as_slice());
     let mut ar = Archive::new(decompressor);
 
@@ -320,6 +327,12 @@ fn rustc_llvm_build(llvm19_enabled: bool) {
         if flag.starts_with("-flto") {
             continue;
         }
+
+        // if we are on msvc, ignore all -W flags as msvc uses /W and -W is invalid.
+        if target.contains("msvc") && flag.starts_with("-W") {
+            continue;
+        }
+
         // ignore flags that aren't supported in gcc 8
         if flag == "-Wcovered-switch-default" {
             continue;


### PR DESCRIPTION
## Summary

1. **Broken LLVM Download URL:** The hardcoded download URL incorrectly used the uppercase tag LLVM-7.1.0 (which has no release assets), instead of the correct lowercase tag llvm-7.1.0. Because curl didn't verify the HTTP response code, the script was attempting to unpack a GitHub 404 HTML page as a tarball, resulting in an obscure UnexpectedEof / TarError panic.
2. **Invalid MSVC Compiler Flags:** When the `cc` crate attempts to compile the LLVM C++ shim (`RustWrapper.cpp`) using MSVC (`cl.exe`), it blindly passes all flags returned by `llvm-config --cxxflags`. Since the prebuilt LLVM was cross-compiled, `llvm-config` returns GCC-style warning flags (e.g. `-Wextra`), which causes MSVC to fail with a `D8021 : invalid numeric argument '/Wextra'` error.

## Changes

- Corrected PREBUILT_LLVM_URL_LLVM7 to use the lowercase llvm-7.1.0 tag.
- Added an explicit HTTP response code check to catch download failures immediately. It will now fail with a clear, actionable error message showing the bad URL and response code.
- Added logic to filter out all GCC-style warning flags (`-W*`) when compiling the C++ shim if the target contains "msvc".

## Testing

- [x] cargo build passes
- [x] cargo clippy --workspace passes
- [x] Tested on: Windows / Linux

## Notes

This issue manifested as build failures specifically when running cargo build in a clean Windows environment where USE_PREBUILT_LLVM triggers.