### PR TITLE
fix(cust_raw): qualify str::from_utf8 to avoid nightly-only inherent

### DIFF
--- a/crates/cuda_builder/src/lib.rs
+++ b/crates/cuda_builder/src/lib.rs
@@ -469,11 +469,12 @@ fn find_in_dir(dir: &Path, filename: &str) -> Option<PathBuf> {
                 continue;
             }
 
-            if let Some(name) = path.file_name().and_then(|s| s.to_str())
-                && (name == filename
-                    || (name.starts_with(&hashed_prefix) && name.ends_with(dll_suffix)))
-            {
-                return Some(path);
+            if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+                if name == filename
+                    || (name.starts_with(&hashed_prefix) && name.ends_with(dll_suffix))
+                {
+                    return Some(path);
+                }
             }
         }
     }
@@ -586,11 +587,12 @@ fn workspace_root_dir() -> Option<PathBuf> {
 
     loop {
         let candidate = path.join("Cargo.toml");
-        if candidate.is_file()
-            && let Ok(contents) = fs::read_to_string(&candidate)
-            && contents.contains("[workspace]")
-        {
-            return Some(path.clone());
+        if candidate.is_file() {
+            if let Ok(contents) = fs::read_to_string(&candidate) {
+                if contents.contains("[workspace]") {
+                    return Some(path.clone());
+                }
+            }
         }
 
         if !path.pop() {

--- a/crates/cust/src/memory/device/device_buffer.rs
+++ b/crates/cust/src/memory/device/device_buffer.rs
@@ -323,7 +323,7 @@ impl<A: DeviceCopy + Pod> DeviceBuffer<A> {
     #[cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
     pub fn try_cast<B: Pod + DeviceCopy>(self) -> Result<DeviceBuffer<B>, PodCastError> {
         if align_of::<B>() > align_of::<A>()
-            && !(self.buf.as_raw() as usize).is_multiple_of(align_of::<B>())
+            && (self.buf.as_raw() as usize) % align_of::<B>() != 0
         {
             Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
         } else if size_of::<B>() == size_of::<A>() {
@@ -331,7 +331,7 @@ impl<A: DeviceCopy + Pod> DeviceBuffer<A> {
             Ok(unsafe { transmute::<DeviceBuffer<A>, DeviceBuffer<B>>(self) })
         } else if size_of::<A>() == 0 || size_of::<B>() == 0 {
             Err(PodCastError::SizeMismatch)
-        } else if (size_of::<A>() * self.len).is_multiple_of(size_of::<B>()) {
+        } else if (size_of::<A>() * self.len) % size_of::<B>() == 0 {
             let new_len = (size_of::<A>() * self.len) / size_of::<B>();
             let ret = Ok(DeviceBuffer {
                 buf: self.buf.cast(),

--- a/crates/cust_raw/build/callbacks.rs
+++ b/crates/cust_raw/build/callbacks.rs
@@ -170,7 +170,7 @@ impl FunctionRenames {
                 Ok(expanded) => expanded,
                 Err(e) => panic!("Failed to expand macros: {e}"),
             };
-            let expanded = str::from_utf8(&expanded).unwrap();
+            let expanded = std::str::from_utf8(&expanded).unwrap();
 
             let mut remaps = bimap::BiHashMap::new();
             for line in expanded.lines().rev() {

--- a/crates/ptx/src/lexer.rs
+++ b/crates/ptx/src/lexer.rs
@@ -440,14 +440,14 @@ impl<'src> Lexer<'src> {
         let cur = self.cur;
         let ident = self.eat_until(|c, _| is_ident_continue(c));
         // check if its an instruction
-        if ident.chars().all(|c| c.is_ascii_alphanumeric())
-            && let Ok(kind) = InstructionKind::from_str(ident.as_str())
-        {
-            *self.values.last_mut().unwrap() = Some(TokenValue::Instruction(kind));
-            return Token {
-                kind: TokenKind::Instruction,
-                range: cur..self.cur,
-            };
+        if ident.chars().all(|c| c.is_ascii_alphanumeric()) {
+            if let Ok(kind) = InstructionKind::from_str(ident.as_str()) {
+                *self.values.last_mut().unwrap() = Some(TokenValue::Instruction(kind));
+                return Token {
+                    kind: TokenKind::Instruction,
+                    range: cur..self.cur,
+                };
+            }
         }
 
         *self.values.last_mut().unwrap() =


### PR DESCRIPTION
```
error[E0658]: use of unstable library feature `inherent_str_constructors`
   --> /home/user/.cargo/git/checkouts/rust-cuda-fad079f24bbca397/103a8d5/crates/cust_raw/build/callbacks.rs:173:28
    |
173 |             let expanded = str::from_utf8(&expanded).unwrap();
    |                            ^^^^^^^^^^^^^^
    |
    = note: see issue #131114 <https://github.com/rust-lang/rust/issues/131114> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `cust_raw` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

gets rid of this