### PR TITLE
fix: KernelInvocation::from_raw uses grid dimensions for block dimensions

### DIFF
--- a/crates/cust/src/graph.rs
+++ b/crates/cust/src/graph.rs
@@ -110,7 +110,7 @@ impl KernelInvocation {
         Self {
             func: raw.func,
             grid_dim: GridSize::xyz(raw.gridDimX, raw.gridDimY, raw.gridDimZ),
-            block_dim: BlockSize::xyz(raw.blockDimX, raw.gridDimY, raw.gridDimZ),
+            block_dim: BlockSize::xyz(raw.blockDimX, raw.blockDimY, raw.blockDimZ),
             params: Box::from_raw(raw.kernelParams),
             shared_mem_bytes: raw.sharedMemBytes,
             params_len: None,


### PR DESCRIPTION


## Testing

- [x] `cargo build` passes
- [ ] `cargo clippy --workspace` passes
- [ ] Tested on: [OS, GPU, CUDA version]

## Notes

Any additional context for reviewers.
