### PR TITLE
fix(atomic): use system memory scope for SystemAtomic types

### DIFF
--- a/crates/cuda_std/src/atomic.rs
+++ b/crates/cuda_std/src/atomic.rs
@@ -252,5 +252,5 @@ atomic_float!(f32, AtomicF32, 4, device, 32);
 atomic_float!(f64, AtomicF64, 8, device, 64);
 atomic_float!(f32, BlockAtomicF32, 4, block, 32, unsafe);
 atomic_float!(f64, BlockAtomicF64, 8, block, 64, unsafe);
-atomic_float!(f32, SystemAtomicF32, 4, device, 32);
-atomic_float!(f64, SystemAtomicF64, 8, device, 64);
+atomic_float!(f32, SystemAtomicF32, 4, system, 32);
+atomic_float!(f64, SystemAtomicF64, 8, system, 64);


### PR DESCRIPTION
## Summary
  
`SystemAtomicF32` and `SystemAtomicF64` previously used the `device` domain scope instead of the intended `system` scope in their macro instantiations. This mismatch caused `.gpu` scoped atomic PTX instructions to be emitted (`atomic.  global.gpu...`) rather than `.sys` scoped instructions. 
  
This bug meant that any system-level synchronization (between the host CPU and GPU, or across multiple GPUs over PCIe/NVLink) would fail to observe proper cache coherency, silently causing data races and corrupted shared memory states. This PR corrects the macro arguments to use the correct `system` scope for system atomics.


Closes #399

## Changes

- Changed the `$scope` argument for `SystemAtomicF32` and `SystemAtomicF64` from `device` to `system` in `crates/cuda_std/src/atomic.rs`.

## Testing

- [x] `cargo build` passes
- [x] `cargo clippy --workspace` passes
- [x] Tested on: Ubuntu 24.04.1 LTS, NVIDIA GeForce RTX 5060 Ti, CUDA 12.8.93

