### PR TITLE
fix(nvvm): cast bit-counting intrinsic results back to the return width

### DIFF
--- a/crates/rustc_codegen_nvvm/src/intrinsic.rs
+++ b/crates/rustc_codegen_nvvm/src/intrinsic.rs
@@ -605,7 +605,7 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 }
                 let (size, signed) = ty.int_size_and_signed(self.tcx);
                 let width = size.bits();
-                if name == sym::saturating_add || name == sym::saturating_sub {
+                let llret = if name == sym::saturating_add || name == sym::saturating_sub {
                     saturating_intrinsic_impl(
                         self,
                         width as u32,
@@ -673,7 +673,18 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                         }
                         _ => unreachable!(),
                     }
-                }
+                };
+                // `ctpop`, `ctlz`, `cttz` and their `_nonzero` variants are declared in `core` as
+                // returning `u32` for *every* operand width, while the corresponding LLVM
+                // intrinsics return a value as wide as their operand. Without this cast the
+                // oversized value is stored into the 4-byte result slot, where it is either
+                // dropped as an out-of-bounds store (`u64`/`u128`, yielding a constant `0`) or
+                // leaves the high bytes uninitialized (`u8`/`u16`).
+                //
+                // Casting to an identical type is a no-op, so the intrinsics in this arm that do
+                // return the operand width (`bswap`, `bitreverse`, `rotate_*`, `saturating_*`)
+                // are unaffected, and any intrinsic added here later is covered automatically.
+                self.intcast(llret, result.layout.llvm_type(self), false)
             }
             sym::raw_eq => {
                 use rustc_codegen_ssa::common::IntPredicate;

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -28,7 +28,7 @@ around to adding it yet.
 | Match | ✔️ |
 | Proc Macros | ✔️ |
 | Try (`?`) | ✔️ |
-| 128 bit integers | 🟨 | Basic ops should work (and are emulated), advanced intrinsics like `ctpop`, `rotate`, etc are unsupported. |
+| 128 bit integers | 🟨 | Basic ops should work (and are emulated). The bit-manipulation intrinsics (`count_ones`, `leading_zeros`, `trailing_zeros`, `swap_bytes`, `reverse_bits`, `rotate_left`/`rotate_right`) are also emulated, over the two 64-bit halves. |
 | Unions | ✔️ |
 | Iterators | ✔️ |
 | Dynamic Dispatch | ✔️ |

--- a/tests/compiletests/ui/dis/count_ones_u128.rs
+++ b/tests/compiletests/ui/dis/count_ones_u128.rs
@@ -1,0 +1,18 @@
+// build-pass
+// compile-flags: -Cllvm-args=--disassemble-entry=count_ones_u128 --error-format=human -Cdebuginfo=0
+
+// Regression test for the emulated 128-bit path: `handle_128_bit_intrinsic` returns an `i128`,
+// which must be truncated to the `u32` that `core::intrinsics::ctpop` is declared to return.
+// Without the truncation the 16-byte store into the 4-byte result slot is discarded and both
+// `popc`s are eliminated as dead, so `u128::count_ones` silently returns `0` on device.
+//
+// The kernel below must contain two `popc.b64`s and the `add` that combines them.
+
+use cuda_std::kernel;
+
+#[kernel]
+pub unsafe fn count_ones_u128(buffer: *const u128, out: *mut u32) {
+    unsafe {
+        *out = (*buffer).count_ones();
+    }
+}

--- a/tests/compiletests/ui/dis/count_ones_u128.stderr
+++ b/tests/compiletests/ui/dis/count_ones_u128.stderr
@@ -1,0 +1,25 @@
+.visible .entry count_ones_u128(
+    .param .u64 count_ones_u128_param_0,
+    .param .u64 count_ones_u128_param_1
+)
+{
+    .reg .b32     %r<3>;
+    .reg .b64     %rd<12>;
+
+
+    ld.param.u64     %rd1, [count_ones_u128_param_0];
+    ld.param.u64     %rd2, [count_ones_u128_param_1];
+    cvta.to.global.u64     %rd3, %rd2;
+    cvta.to.global.u64     %rd4, %rd1;
+    ld.global.v2.u64     {%rd5, %rd6}, [%rd4];
+    popc.b64     %r1, %rd5;
+    cvt.u64.u32     %rd9, %r1;
+    popc.b64     %r2, %rd6;
+    cvt.u64.u32     %rd10, %r2;
+    add.s64     %rd11, %rd9, %rd10;
+    st.global.u32     [%rd3], %rd11;
+    ret;
+
+}
+
+

--- a/tests/compiletests/ui/dis/count_ones_u64.rs
+++ b/tests/compiletests/ui/dis/count_ones_u64.rs
@@ -1,0 +1,18 @@
+// build-pass
+// compile-flags: -Cllvm-args=--disassemble-entry=count_ones_u64 --error-format=human -Cdebuginfo=0
+
+// Regression test: `core::intrinsics::ctpop` returns `u32` for every operand width, so the
+// `i64` result of `llvm.ctpop.i64` has to be truncated before it is stored into the `u32`
+// result slot. Without that truncation the oversized store is dropped and the `popc` is
+// eliminated as dead, so `count_ones` silently returns `0` on device.
+//
+// The kernel below must contain a `popc.b64`.
+
+use cuda_std::kernel;
+
+#[kernel]
+pub unsafe fn count_ones_u64(buffer: *const u64, out: *mut u32) {
+    unsafe {
+        *out = (*buffer).count_ones();
+    }
+}

--- a/tests/compiletests/ui/dis/count_ones_u64.stderr
+++ b/tests/compiletests/ui/dis/count_ones_u64.stderr
@@ -1,0 +1,22 @@
+.visible .entry count_ones_u64(
+    .param .u64 count_ones_u64_param_0,
+    .param .u64 count_ones_u64_param_1
+)
+{
+    .reg .b32     %r<2>;
+    .reg .b64     %rd<7>;
+
+
+    ld.param.u64     %rd1, [count_ones_u64_param_0];
+    ld.param.u64     %rd2, [count_ones_u64_param_1];
+    cvta.to.global.u64     %rd3, %rd2;
+    cvta.to.global.u64     %rd4, %rd1;
+    ld.global.u64     %rd5, [%rd4];
+    popc.b64     %r1, %rd5;
+    cvt.u64.u32     %rd6, %r1;
+    st.global.u32     [%rd3], %rd6;
+    ret;
+
+}
+
+

--- a/tests/compiletests/ui/dis/leading_zeros_u64.rs
+++ b/tests/compiletests/ui/dis/leading_zeros_u64.rs
@@ -1,0 +1,18 @@
+// build-pass
+// compile-flags: -Cllvm-args=--disassemble-entry=leading_zeros_u64 --error-format=human -Cdebuginfo=0
+
+// Regression test: like `ctpop`, `core::intrinsics::ctlz` returns `u32` for every operand
+// width, so the `i64` result of `llvm.ctlz.i64` has to be truncated before it is stored into
+// the `u32` result slot. Without that truncation the oversized store is dropped and the
+// `clz` is eliminated as dead, so `leading_zeros` silently returns `0` on device.
+//
+// The kernel below must contain a `clz.b64`.
+
+use cuda_std::kernel;
+
+#[kernel]
+pub unsafe fn leading_zeros_u64(buffer: *const u64, out: *mut u32) {
+    unsafe {
+        *out = (*buffer).leading_zeros();
+    }
+}

--- a/tests/compiletests/ui/dis/leading_zeros_u64.stderr
+++ b/tests/compiletests/ui/dis/leading_zeros_u64.stderr
@@ -1,0 +1,22 @@
+.visible .entry leading_zeros_u64(
+    .param .u64 leading_zeros_u64_param_0,
+    .param .u64 leading_zeros_u64_param_1
+)
+{
+    .reg .b32     %r<2>;
+    .reg .b64     %rd<7>;
+
+
+    ld.param.u64     %rd1, [leading_zeros_u64_param_0];
+    ld.param.u64     %rd2, [leading_zeros_u64_param_1];
+    cvta.to.global.u64     %rd3, %rd2;
+    cvta.to.global.u64     %rd4, %rd1;
+    ld.global.u64     %rd5, [%rd4];
+    clz.b64     %r1, %rd5;
+    cvt.u64.u32     %rd6, %r1;
+    st.global.u32     [%rd3], %rd6;
+    ret;
+
+}
+
+


### PR DESCRIPTION
Fixes #401.

`core::intrinsics::{ctpop, ctlz, cttz, ctlz_nonzero, cttz_nonzero}` are declared as returning `u32` for every operand width, while the LLVM intrinsics they lower to return a value as wide as their operand. `rustc_codegen_llvm` casts the result back (the `intcast(ret, result.layout.llvm_type(self), false)` in each arm of `compiler/rustc_codegen_llvm/src/intrinsic.rs`); this backend never has.

The oversized value was then stored into the 4-byte result slot. For `u64`/`u128` that store is out of bounds for the slot, so it is discarded, the intrinsic call becomes dead, and the device silently computes `0`. For `u8`/`u16` the store is in bounds and the high bytes of the result are left uninitialized. Width 32 was the only correct width, because there the cast is a no-op.

This is easy to see in the emitted PTX. Before this change, the entire body of

```rust
#[kernel]
pub unsafe fn count_ones_u64(buffer: *const u64, out: *mut u32) {
    unsafe { *out = (*buffer).count_ones(); }
}
```

is gone -- no `popc`, and not even the store:

```ptx
.visible .entry count_ones_u64(
    .param .u64 count_ones_u64_param_0,
    .param .u64 count_ones_u64_param_1
)
{
    ret;
}
```

After, the `popc.b64` is there and the result is stored, and the resulting SASS is a correct 64-bit population count (`POPC` / `POPC` / `IADD3` / `STG.E`).

## The fix

Rather than wrapping each of the five arms individually (and `handle_128_bit_intrinsic`, which is a free function with no `result` in scope), the whole arm is wrapped in a single `intcast` to the intrinsic's result layout. Casting to an identical type is a no-op, so the intrinsics in that arm which do return the operand width -- `bswap`, `bitreverse`, `rotate_*`, `saturating_*` -- are unaffected, and any intrinsic added there later is covered automatically.

## Tests

Three `dis` compiletests pin the emitted PTX:

- `count_ones_u64` -- must contain `popc.b64`
- `leading_zeros_u64` -- must contain `clz.b64`
- `count_ones_u128` -- exercises the separate emulated `handle_128_bit_intrinsic` path; must contain two `popc.b64` plus the combining `add`

All three compiled down to a bare `ret` before this change. They pass `-Cdebuginfo=0` so the goldens do not embed `library/core` line numbers, which would otherwise churn on every `rust-toolchain.toml` bump.

Verified in `ghcr.io/rust-gpu/rust-cuda-ubuntu24-cuda12`: full compiletest suite green across `compute_61,compute_75,compute_90` (66 passed), and `cargo fmt --all -- --check` plus `cargo clippy -p rustc_codegen_nvvm` clean with `RUSTFLAGS=-Dwarnings`.

Also corrects the 128-bit row in `guide/src/features.md`, which claimed the bit-manipulation intrinsics were unsupported -- they are emulated over the two 64-bit halves, and with this fix they return correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
