### PR TITLE
fix(warp): properly interpret floating point numbers in match_any

### DIFF
--- a/crates/cuda_std/src/warp.rs
+++ b/crates/cuda_std/src/warp.rs
@@ -272,7 +272,7 @@ macro_rules! impl_match {
                     }
                     unsafe fn match_all(mask: u32, value: Self) -> Option<u32> {
                         let (val, pred) = unsafe { [<match_all_ $width>](mask, value as [<u $width>]) };
-                        pred.then(|| val)
+                        pred.then_some(val)
                     }
                 }
             }
@@ -285,8 +285,26 @@ impl_match! {
     i64, 64,
     u32, 32,
     u64, 64,
-    f32, 32,
-    f64, 64,
+}
+
+impl WarpMatchValue for f32 {
+    unsafe fn match_any(mask: u32, value: Self) -> u32 {
+        unsafe { match_any_32(mask, value.to_bits()) }
+    }
+    unsafe fn match_all(mask: u32, value: Self) -> Option<u32> {
+        let (val, pred) = unsafe { match_all_32(mask, value.to_bits()) };
+        pred.then_some(val)
+    }
+}
+
+impl WarpMatchValue for f64 {
+    unsafe fn match_any(mask: u32, value: Self) -> u32 {
+        unsafe { match_any_64(mask, value.to_bits()) }
+    }
+    unsafe fn match_all(mask: u32, value: Self) -> Option<u32> {
+        let (val, pred) = unsafe { match_all_64(mask, value.to_bits()) };
+        pred.then_some(val)
+    }
 }
 
 #[gpu_only]


### PR DESCRIPTION
## Summary

This PR fixes a critical logic bug in `WarpMatchValue` where `f32` and `f64` types were being incorrectly processed by the generic `impl_match!` macro. 

The macro dynamically applies integer casting (`value as u32` and `value as u64`) to cast inputs to bitmasks before executing the underlying SIMT PTX intrinsic. While this acts as a safe bitwise transmute for values like `i32`, in Rust, casting a float via `as u32` executes a **truncating numeric conversion**. For example, both `1.1f32` and `1.9f32` truncate to `1u32`, and all negative floats cast identically to `0`. Consequently, operations like `warp_match_any` between completely distinct floats would silently evaluate as a perfect match, catastrophically corrupting thread convergence checks and logic algorithms expecting structural equality. 
Closes #406

## Changes

* Removed the `f32` and `f64` types from the `impl_match!` macro in `crates/cuda_std/src/warp.rs` to prevent integer cascading behavior.
* Implemented `WarpMatchValue` manually for `f32`, strictly leveraging `value.to_bits()` to route structural memory bits into `match_any_32` and `match_all_32`.
* Implemented `WarpMatchValue` manually for `f64`, strictly leveraging `value.to_bits()` to route structural memory bits into `match_any_64` and `match_all_64`.

## Testing

- [x] `cargo build` passes
- [x] `cargo clippy --workspace` passes
- [x] Tested on: Ubuntu 24.04.1 LTS, NVIDIA GeForce RTX 5060 Ti, CUDA 12.8.93

